### PR TITLE
make list item text black in PDF export

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -1264,6 +1264,9 @@ FOR EXPORT
   p {
     color: black !important;
   }
+  li {
+    color: black !important;
+  }
   ul > li::before,
   ol > li::before {
     border-left: 1px solid #ecedf1;


### PR DESCRIPTION
When using dark mode, list item text was being exported as white-on-white

before:
![image](https://user-images.githubusercontent.com/18692749/135482381-743d6d46-72e2-46a4-b3f1-d3633c5359d5.png)
after:
![image](https://user-images.githubusercontent.com/18692749/135482324-f656bd17-e2f8-4167-aeef-384ebffa0d87.png)
