### PR TITLE
Fix: 1. live preview does not respect header size and weight 2. Misaligned checkboxes in live preview

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -4072,6 +4072,11 @@ input[type="checkbox"],
   box-shadow: inset 0px 0.5px 1px var(--background-zero);
 }
 
+input[type="checkbox"],
+.markdown-source-view.mod-cm6 .task-list-item-checkbox  {
+  vertical-align: top;
+}
+
 .is-mobile input[type="checkbox"],
 .is-mobile .markdown-preview-view .task-list-item-checkbox {
   margin-left: 3px;

--- a/obsidian.css
+++ b/obsidian.css
@@ -1963,8 +1963,6 @@ HEADINGS
 .cm-s-obsidian .cm-header.cm-header-6 {
   font-family: var(--header-font-ed);
   color: inherit;
-  font-size: inherit;
-  font-weight: inherit;
   font-style: inherit;
   line-height: inherit;
 }


### PR DESCRIPTION
Hi Chetachi!

As I have been using the theme with Live Preview, I encountered two annoying bugs:

1. Headers are rendered in the default text size and no header font weight
2. Checkboxes are misaligned with their item text

This screenshot should clarify what I mean:

![image](https://user-images.githubusercontent.com/23149353/146194561-ea37cd2f-4fdd-430a-ae86-db033e2ed4c4.png)

In this pull request I made two commits that should provide a quick fix for both of these issues.

Fixed result:

![image](https://user-images.githubusercontent.com/23149353/146194782-cc890c1b-1664-46f6-bb83-159e2d046b53.png)

Let me know what you think.


