### PR TITLE
Update heading size styling to work with v0.13.30

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -1984,6 +1984,7 @@ HEADINGS
 }
 
 body.is-mobile .HyperMD-header-1,
+.HyperMD-header-1,
 .CodeMirror .CodeMirror-line.HyperMD-header-1,
 .markdown-preview-section h1 {
   line-height: 1.2em;
@@ -1993,6 +1994,7 @@ body.is-mobile .HyperMD-header-1,
 }
 
 body.is-mobile .HyperMD-header-2,
+.HyperMD-header-2,
 .CodeMirror .CodeMirror-line.HyperMD-header-2,
 .markdown-preview-section h2 {
   line-height: 1.2em;
@@ -2002,6 +2004,7 @@ body.is-mobile .HyperMD-header-2,
 }
 
 body.is-mobile .HyperMD-header-3,
+.HyperMD-header-3,
 .CodeMirror .CodeMirror-line.HyperMD-header-3,
 .markdown-preview-section h3 {
   line-height: 1.2em;
@@ -2011,6 +2014,7 @@ body.is-mobile .HyperMD-header-3,
 }
 
 body.is-mobile .HyperMD-header-4,
+.HyperMD-header-4,
 .CodeMirror .CodeMirror-line.HyperMD-header-4,
 .markdown-preview-section h4 {
   font-weight: 650;
@@ -2019,6 +2023,7 @@ body.is-mobile .HyperMD-header-4,
 }
 
 body.is-mobile .HyperMD-header-5,
+.HyperMD-header-5,
 .CodeMirror .CodeMirror-line.HyperMD-header-5,
 .markdown-preview-section h5 {
   line-height: 1.2em;
@@ -2028,6 +2033,7 @@ body.is-mobile .HyperMD-header-5,
 }
 
 body.is-mobile .HyperMD-header-6,
+.HyperMD-header-6,
 .CodeMirror .CodeMirror-line.HyperMD-header-6,
 .markdown-preview-section h6 {
   font-weight: 600;


### PR DESCRIPTION
Some of the classes appear to have changed in the latest version, breaking heading font-sizes on most themes. I added this as additions since I'm sure entirely sure what's for the new editor, old editor, what's going on with mobile, etc, and didn't want to break compatibility.

This worked for me. Happy to alter it if there's a method to the selectors that I'm not seeing.

Cheers!