### PR TITLE
Update Yin and Yang to latest Obsidian version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,3 @@
-# Purpose
-This repository is a fork of https://github.com/chetachiezikeuzor/Yin-and-Yang-Theme. I love this theme, but it is unfortunately outdated and no longer appears in Obsidian's theme explorer. I have integrated the theme supplied by https://github.com/TOB-KNPOB/Yin-and-Yang-Theme to match the structure of https://github.com/colineckert/obsidian-things so that it can be installed again. 
-
-# How to install
-Follow these steps:
-1. Navigate to your vault's root directory. 
-2. Head to `.obsidian/themes`
-3. If it does not already exist, create a new directory named `Yin and Yang`
-4. Copy the files [`theme.css`](https://raw.githubusercontent.com/DevJake/Yin-and-Yang-Theme/main/theme.css) and [`manifest.json`](https://raw.githubusercontent.com/DevJake/Yin-and-Yang-Theme/main/manifest.json) into here. 
-5. Open Obsidian and locate the theme named `Yin and Yang` in the dropdown -- you might need to reopen Obsidian if it does not show. 
-
-
-
 # Yin and Yang
 
 ![](https://raw.githubusercontent.com/chetachiezikeuzor/Yin-and-Yang-Theme/main/assets/screenshot.png)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+# Purpose
+This repository is a fork of https://github.com/chetachiezikeuzor/Yin-and-Yang-Theme. I love this theme, but it is unfortunately outdated and no longer appears in Obsidian's theme explorer. I have integrated the theme supplied by https://github.com/TOB-KNPOB/Yin-and-Yang-Theme to match the structure of https://github.com/colineckert/obsidian-things so that it can be installed again. 
+
+# How to install
+Follow these steps:
+1. Navigate to your vault's root directory. 
+2. Head to `.obsidian/themes`
+3. If it does not already exist, create a new directory named `Yin and Yang`
+4. Copy the files [`theme.css`](https://raw.githubusercontent.com/DevJake/Yin-and-Yang-Theme/main/theme.css) and [`manifest.json`](https://raw.githubusercontent.com/DevJake/Yin-and-Yang-Theme/main/manifest.json) into here. 
+5. Open Obsidian and locate the theme named `Yin and Yang` in the dropdown -- you might need to reopen Obsidian if it does not show. 
+
+
+
 # Yin and Yang
 
 ![](https://raw.githubusercontent.com/chetachiezikeuzor/Yin-and-Yang-Theme/main/assets/screenshot.png)

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,7 @@
+{
+  "name": "Yin and Yang",
+  "version": "1.1.0",
+  "minAppVersion": "1.0.0",
+  "author": "@chetachiezkeuzor",
+  "authorUrl": "https://twitter.com/chetachiiii"
+}

--- a/theme.css
+++ b/theme.css
@@ -1,0 +1,10021 @@
+/* @settings
+
+name: Yin and Yang Theme
+id: Yin and Yang
+settings:
+  - 
+    id: accent-color-title
+    title: Accent Color
+    description: For links and interactive elements.
+    type: heading
+    level: 3
+    collapsed: false 
+  - 
+    id: l-accent
+    title: Light Mode Accent Color
+    type: variable-color
+    format: hsl-split
+    default: '#DAAFFF' 
+  - 
+    id: d-accent
+    title: Dark Mode Accent Color
+    type: variable-color
+    format: hsl-split
+    default: '#FFCCF1'
+  - 
+    id: base-colors
+    title: Base Color
+    description: Change base hue and saturation.
+    type: heading
+    level: 3
+    collapsed: false 
+  -
+    title: Base Hue
+    id: base-h
+    type: variable-number-slider
+    default: 205
+    min: 0
+    max: 330
+    step: 1 
+  -
+    title: Base Saturation
+    id: base-s
+    type: variable-number-slider
+    default: 23
+    format: '%'
+    min: 1
+    max: 100
+    step: 1 
+  -
+    title: Base Darkness
+    id: base-d
+    type: variable-number-slider
+    default: 5
+    format: '%'
+    min: 4
+    max: 32
+    step: 1 
+  -
+    id: custom-fonts
+    title: Custom Fonts
+    description: For customizing theme fonts.
+    type: heading
+    level: 3
+    collapsed: true
+  - 
+    id: default-font
+    title: UI Font
+    description: Font used for the user interface
+    type: variable-text
+    default: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Microsoft YaHei Light", sans-serif
+  - 
+    id: preview-font
+    title: Preview Font
+    description: Font used for the preview view
+    type: variable-text
+    default: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Microsoft YaHei Light", sans-serif
+  - 
+    id: header-font-pre
+    title: Headers in Preview Font
+    description: Font used for the headers in preview
+    type: variable-text
+    default: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Microsoft YaHei Light", sans-serif
+  - 
+    id: editor-font
+    title: Editor Font
+    description: Font used for the editor view
+    type: variable-text
+    default: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Microsoft YaHei Light", sans-serif
+  - 
+    id: header-font-ed
+    title: Headers in Editor Font
+    description: Font used for the headers in editor
+    type: variable-text
+    default: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Microsoft YaHei Light", sans-serif
+  - 
+    id: font-monospace
+    title: Monospace Font
+    description: Used for code blocks, front matter, etc
+    type: variable-text
+    default: Source Code Pro, monospace
+  -
+    id: typography
+    title: Typography
+    description: Extra typographical features.
+    type: heading
+    level: 3
+    collapsed: true
+  - 
+    id: wys-headings
+    title: WYSIWYG Headings in Editor 
+    description: Adds WYSIWYG-like functionality for headings in editor
+    type: class-toggle
+  - 
+    id: wys-enhanced
+    title: Enhanced Editor Typography
+    description: Adds enhanced WYSIWYG-like functionality in editor
+    type: class-toggle
+  - 
+    id: rainbow-headers
+    title: Rainbow Headers
+    description: Adds rainbow colors for headers
+    type: class-toggle
+  - 
+    id: line-width
+    title: Readable Line Width
+    description: The maximum line width in rem units for readable line width
+    type: variable-number
+    default: 47
+    format: rem
+  - 
+    id: editor-line-height
+    title: Body Line Height
+    description: Line height of the main text, expects a decimal value
+    type: variable-number
+    default: 1.756666  
+  -
+    id: l-blockquote 
+    title: Light Mode Block Quote Color
+    type: variable-color
+    format: hsl-split
+    default: '#FF66E5'
+  - 
+    id: d-blockquote
+    title: Dark Mode Block Quote Color
+    type: variable-color
+    format: hsl-split
+    default:  '#FFADF1'
+  -
+    title: Italicized Text Color
+    id: em-color
+    type: variable-themed-color
+    format: hex
+    default-dark: '#84B6FF'
+    default-light: '#4A94FF'
+  -
+    title: Bold Text Color 
+    id: strong-color
+    type: variable-themed-color
+    format: hex
+    default-dark: '#FFADF1'
+    default-light: '#FF66E5'
+  -
+    title: Highlight Color 
+    id: text-highlight-rgb
+    type: variable-themed-color
+    format: hex
+    description: This will change the color of highlights in light and dark mode
+    default-dark: '#F2B3CF'
+    default-light: '#FFF3A3'
+  -
+    title: Heading Changes
+    id: heading-changes
+    description: Editing headings individually.
+    type: heading
+    level: 3
+    collapsed: true
+  -
+    title: Heading Fonts
+    id: heading-fonts
+    type: heading
+    level: 4
+    collapsed: true
+  -
+    title: Change Heading Fonts
+    description: This will allow for editing of headings individually.
+    id: spec-font-head
+    type: class-toggle
+  - 
+    title: Heading 1 Font Preview
+    id: f-header-1-pre
+    type: variable-text
+    default: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Microsoft YaHei Light", sans-serif
+  - 
+    title: Heading 1 Font Editor
+    id: f-header-1-ed
+    type: variable-text
+    default: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Microsoft YaHei Light", sans-serif
+  - 
+    title: Heading 2 Font Preview
+    id: f-header-2-pre
+    type: variable-text
+    default: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Microsoft YaHei Light", sans-serif
+  - 
+    title: Heading 2 Font Editor
+    id: f-header-2-ed
+    type: variable-text
+    default: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Microsoft YaHei Light", sans-serif
+  - 
+    title: Heading 3 Font Preview
+    id: f-header-3-pre
+    type: variable-text
+    default: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Microsoft YaHei Light", sans-serif
+  - 
+    title: Heading 3 Font Editor
+    id: f-header-3-ed
+    type: variable-text
+    default: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Microsoft YaHei Light", sans-serif
+  - 
+    title: Heading 4 Font Preview
+    id: f-header-4-pre
+    type: variable-text
+    default: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Microsoft YaHei Light", sans-serif
+  - 
+    title: Heading 4 Font Editor
+    id: f-header-4-ed
+    type: variable-text
+    default: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Microsoft YaHei Light", sans-serif
+  - 
+    title: Heading 5 Font Preview
+    id: f-header-5-pre
+    type: variable-text
+    default: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Microsoft YaHei Light", sans-serif
+  - 
+    title: Heading 5 Font Editor
+    id: f-header-5-ed
+    type: variable-text
+    default: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Microsoft YaHei Light", sans-serif
+  - 
+    title: Heading 6 Font Preview
+    id: f-header-6-pre
+    type: variable-text
+    default: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Microsoft YaHei Light", sans-serif
+  - 
+    title: Heading 6 Font Editor
+    id: f-header-6-ed
+    type: variable-text
+    default: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Microsoft YaHei Light", sans-serif
+  -
+    title: Heading Size
+    id: spec-size-head
+    type: heading
+    level: 4
+    collapsed: true
+  -
+    title: Change Heading Sizes
+    description: This will allow for editing of headings individually.
+    id: spec-size-head
+    type: class-toggle
+  -
+    title: Heading 1 Size Preview
+    id: s-header-1-pre
+    type: variable-number-slider
+    default: 1.98
+    format: em
+    min: 1
+    max: 3
+    step: .15 
+  -
+    title: Heading 1 Size Editor
+    id: s-header-1-ed
+    type: variable-number-slider
+    default: 1.98
+    format: em
+    min: 1
+    max: 3
+    step: .15
+  -
+    title: Heading 2 Size Preview
+    id: s-header-2-pre
+    type: variable-number-slider
+    default: 1.88
+    format: em
+    min: 1
+    max: 3
+    step: .15
+  -
+    title: Heading 2 Size Editor
+    id: s-header-2-ed
+    type: variable-number-slider
+    default: 1.88
+    format: em
+    min: 1
+    max: 3
+    step: .15
+  -
+    title: Heading 3 Size Preview
+    id: s-header-3-pre
+    type: variable-number-slider
+    default: 1.68
+    format: em
+    min: 1
+    max: 3
+    step: .15
+  -
+    title: Heading 3 Size Editor
+    id: s-header-3-ed
+    type: variable-number-slider
+    default: 1.68
+    format: em
+    min: 1
+    max: 3
+    step: .15
+  -
+    title: Heading 4 Size Preview
+    id: s-header-4-pre
+    type: variable-number-slider
+    default: 1.48
+    format: em
+    min: 1
+    max: 3
+    step: .15
+  -
+    title: Heading 4 Size Editor
+    id: s-header-4-ed
+    type: variable-number-slider
+    default: 1.48
+    format: em
+    min: 1
+    max: 3
+    step: .15
+  -
+    title: Heading 5 Size Preview
+    id: s-header-5-pre
+    type: variable-number-slider
+    default: 1.28
+    format: em
+    min: 1
+    max: 3
+    step: .15
+  -
+    title: Heading 5 Size Editor
+    id: s-header-5-ed
+    type: variable-number-slider
+    default: 1.28
+    format: em
+    min: 1
+    max: 3
+    step: .15
+  -
+    title: Heading 6 Size Preview
+    id: s-header-6-pre
+    type: variable-number-slider
+    default: 1.08
+    format: em
+    min: 1
+    max: 3
+    step: .15
+  -
+    title: Heading 6 Size Editor
+    id: s-header-6-ed
+    type: variable-number-slider
+    default: 1.08
+    format: em
+    min: 1
+    max: 3
+    step: .15
+  -
+    title: Heading Color
+    id: spec-size-head
+    type: heading
+    level: 4
+    collapsed: true
+  -
+    title: Change Heading Colors
+    description: This will allow for editing of headings individually.
+    id: spec-color-head
+    type: class-toggle
+  -
+    title: Heading 1 Color Preview
+    id: sphd-pre-1
+    type: variable-themed-color
+    format: hex
+    default-dark: '#EFF1FB'
+    default-light: '#171E45'
+  -
+    title: Heading 1 Color Editor
+    id: sphd-ed-1
+    type: variable-themed-color
+    format: hex
+    default-dark: '#EFF1FB'
+    default-light: '#171E45'
+  -
+    title: Heading 2 Color Preview
+    id: sphd-pre-2
+    type: variable-themed-color
+    format: hex
+    default-dark: '#EFF1FB'
+    default-light: '#171E45'
+  -
+    title: Heading 2 Color Editor
+    id: sphd-ed-2
+    type: variable-themed-color
+    format: hex
+    default-dark: '#EFF1FB'
+    default-light: '#171E45'
+  -
+    title: Heading 3 Color Preview
+    id: sphd-pre-3
+    type: variable-themed-color
+    format: hex
+    default-dark: '#EFF1FB'
+    default-light: '#171E45'
+  -
+    title: Heading 3 Color Editor
+    id: sphd-ed-3
+    type: variable-themed-color
+    format: hex
+    default-dark: '#EFF1FB'
+    default-light: '#171E45'
+  -
+    title: Heading 4 Color Preview
+    id: sphd-pre-4
+    type: variable-themed-color
+    format: hex
+    default-dark: '#EFF1FB'
+    default-light: '#171E45'
+  -
+    title: Heading 4 Color Editor
+    id: sphd-ed-4
+    type: variable-themed-color
+    format: hex
+    default-dark: '#EFF1FB'
+    default-light: '#171E45'
+  -
+    title: Heading 5 Color Preview
+    id: sphd-pre-5
+    type: variable-themed-color
+    format: hex
+    default-dark: '#EFF1FB'
+    default-light: '#171E45'
+  -
+    title: Heading 5 Color Editor
+    id: sphd-ed-5
+    type: variable-themed-color
+    format: hex
+    default-dark: '#EFF1FB'
+    default-light: '#171E45'
+  -
+    title: Heading 6 Color Preview
+    id: sphd-pre-6
+    type: variable-themed-color
+    format: hex
+    default-dark: '#EFF1FB'
+    default-light: '#171E45'
+  -
+    title: Heading 6 Color Editor
+    id: sphd-ed-6
+    type: variable-themed-color
+    format: hex
+    default-dark: '#EFF1FB'
+    default-light: '#171E45'
+  - 
+    title: Minimalize Elements
+    id: minilize-elements
+    description: Minimalize certain workspace elements.
+    type: heading
+    level: 3
+    collapsed: true
+  -
+    title: Custom Icons
+    id: custom-icons-minimalize
+    type: heading
+    level: 4
+  -
+    title: Remove Custom Icons
+    id: no-svg-replace
+    description: This will disable all custom icons 
+    type: class-toggle
+  -
+    title: Animations
+    id: custom-animations-minimalize
+    type: heading
+    level: 4
+  -
+    title: Disable Sidepane Animations
+    id: disable-side-animation
+    description: This will make interactions in sidepanes immediate.
+    type: class-toggle
+  -
+    title: Clean Embeds
+    id: clean-embeds
+    type: heading
+    level: 4
+  -
+    title: Minimalize Embedded Notes
+    id: min-clean-embed
+    description: This will minimalize the look of embed notes
+    type: class-toggle
+  -
+    title: Code Blocks
+    id: code-blocks-minimalize
+    type: heading
+    level: 4
+  -
+    title: Remove Languages
+    description: This will remove code languages from code blocks.
+    id: no-show-lang
+    type: class-toggle
+  -
+    title: Remove Block Borders
+    description: This will remove borders from code blocks.
+    id: no-show-code-block-border
+    type: class-toggle
+  -
+    id: code-font-size
+    title: Change Code Font Size
+    description: This will allow you to set a custom font size for code blocks
+    type: variable-number-slider
+    default: .9
+    format: em
+    min: .5
+    max: 2
+    step: .025
+  -
+    title: Blockquotes
+    id: code-blocks-minimalize
+    type: heading
+    level: 4
+    collapsed: true
+  -
+    id: naked-bq
+    title: Remove Blockquote Icon
+    type: class-toggle
+    description: This will remove the quote icon from all blockquotes
+  -
+    title: Vault
+    id: vault-title-minimalize
+    type: heading
+    level: 4
+    collapsed: true
+  -
+    id: no-show-titlebar-text
+    title: Remove Vault Title
+    type: class-toggle
+    description: This will remove the vault title from the titlebar
+    default: true
+  -
+    title: List Elements
+    id: list-elements-minimalize
+    type: heading
+    level: 4
+    collapsed: true
+  -
+    id: remove-pre-rel-lines
+    title: Remove Relationship Lines in Preview
+    type: class-toggle
+    description: This will remove the relationship lines from your notes in preview mode
+  -
+    id: remove-ed-rel-lines
+    title: Remove Relationship Lines in Editor
+    type: class-toggle
+    description: This will remove the relationship lines from your notes in editor mode
+  -
+    id: custom-line-indent
+    title: Change the Line Indent Value for List
+    description: This will allow you to set a custom line indent value
+    type: variable-number-slider
+    default: 40
+    format: px
+    min: 10
+    max: 80
+    step: 5
+  -
+    id: custom-pre-line-thickness
+    title: Change the Relationship Line Thickness in Preview
+    description: This will allow you to set a custom relationship line thickness in preview
+    type: variable-number-slider
+    default: 1
+    format: px
+    min: 1
+    max: 8
+    step: 1
+  -
+    id: custom-ed-line-thickness
+    title: Change the Relationship Line Thickness in Editor
+    description: This will allow you to set a custom relationship line thickness in editor
+    type: variable-number-slider
+    default: 1
+    format: px
+    min: 1
+    max: 8
+    step: 1
+  - 
+    title: File Explorer 
+    id: heading-specific
+    type: heading
+    level: 4
+    collapsed: true 
+  -
+    title: Remove Custom Icons
+    description: This will remove all custom icons in the file explorer (will also improve scrolling performance).
+    id: no-show-fx-custom-icons
+    type: class-toggle
+  -
+    title: Show Folder Icons
+    description: This will display folder icons (set to none by default for those that wish to use their own icons)
+    id: show-fx-folder-icons
+    type: class-toggle
+  -
+    title: Remove Text Reverse on Attachments 
+    description: This will undo text reverse of attachments and remove attachments icons
+    id: no-fx-reverse 
+    type: class-toggle
+  - 
+    title: Status Bar 
+    id: status-bar-spec
+    type: heading
+    level: 4
+    collapsed: true
+  -
+    title: Remove Status Bar 
+    description: This will hide the status bar and you can hover to see it
+    id: persistent-sb
+    type: class-toggle
+  -
+    title: Remove Status Bar Icon 
+    description: This will remove the ☯️ symbol from the status bar
+    id: no-status-icon
+    type: class-toggle
+  - 
+    title: More Customization
+    id: background-customization
+    description: Extra customizable features.
+    type: heading
+    level: 3
+    collapsed: true
+  - 
+    title: File Explorer 
+    id: heading-specific
+    type: heading
+    level: 4
+    collapsed: true 
+  -
+    title: File Explorer Relationship Lines
+    description: This will add relationship lines to files and folders in file explorer
+    id: fx-rel-lines
+    type: class-toggle
+  - 
+    title: Background Customization 
+    id: heading-specific
+    type: heading
+    level: 4
+    collapsed: true 
+  -
+    title: Background For All Side Panes
+    id: side-panes-bg
+    type: heading
+    level: 5
+  -
+    title: Set background customization for all side panes
+    description: Allows customization of backgrounds for all panes. Simply edit the image url within the "url()" function.
+    id: all-sides
+    type: class-toggle
+  - 
+    title: Side Panes Bkgd
+    id: all-sides-bg
+    type: variable-text
+    default: url()
+  -
+    title: Bkgd Size
+    id: as-size
+    type: variable-text
+    default: 50px
+  -
+    title: Bkgd Filter
+    id: as-filter
+    type: variable-text
+    default: blur(0px) brightness(90%) saturate(0%)
+  -
+    title: Bkgd Repeat/No-Repeat
+    id: as-repeat
+    type: variable-text
+    default: repeat
+  -
+    title: Background For Specific Side Panes
+    id: background-customization
+    type: heading
+    level: 5
+  -
+    title: Set background for specific panes
+    description: Allows customization of backgrounds for specific panes. Simply edit the image url within the "url()" function.
+    id: spec-sides
+    type: class-toggle
+  -
+    title: Graph Panes Bkgd
+    id: graph-input-bg
+    type: variable-text
+    default: url()
+  - 
+    title: File Explorer Bkgd
+    id: fx-input-bg
+    type: variable-text
+    default: url()
+  - 
+    title: Backlinks Bkgd
+    id: backlink-input-bg
+    type: variable-text
+    default: url()
+  - 
+    title: Tag Pane Bkgd
+    id: tag-input-bg
+    type: variable-text
+    default: url()
+  - 
+    title: Calendar Pane Bkgd
+    id: calendar-input-bg
+    type: variable-text
+    default: url()
+  -
+    title: Transparent Window 
+    id: transparent-win-spec
+    type: heading
+    level: 4
+    collapsed: true
+  -
+    title: MacOS-Like Transparent Window
+    description: This will give your workspace a MacOS-like translucency
+    id: macOS-translucent
+    type: class-toggle
+
+*/
+
+/*FONTS (go to https://transfonter.org to generate these if you'd like!) */
+
+@font-face {
+  font-family: "mox-icons";
+  src: url("data:font/woff2;charset=utf-8;base64,d09GMgABAAAAAAdgAA0AAAAAD2QAAAcLAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP0ZGVE0cGh4GVgCCShEICpIAjVcLIgABNgIkAygEIAWFFAdCGzAMUZQtUp/sx0FOxmuarF2cgkNr8bprNXHzgwfCYlZaST//nfbnjnsnLuRMKqVdOag4swByl0yyspJ12if+wb+bo5tHeCBNjIqiBH6t1gDAhBJLj4B+v3TfEdg4IBwfGQdkmVXmZJKSvEpA36msq6tEdGWh/v/Nqb1L2SWuln4JhKsw7FRyLV87YHJMwhAZNaGYFD4/2Te3qelaN+u2xK4W6HUP8l4AgACA70iqAADwbYfrv37dAEAFIAQABaFpIUzmJgAoAd3AAuo85gGwCX4e/WQMAqCwceZNRy6NLWh1hgQAQHMCAQBQKwFoPhVVwHUU8RwjjeMwxhSAYRGVAdQExf5HxM2AUlIsipFQEdNNpItOJFPpneGfi6pEEU21SIfjUKkV9QnQx67M82kMAYNDE1EoDB5CP6lGi3Gw3sCBMkoIFEqjeDWjjObFoAikExcSJqj5IM7AFQkavUFI4bkFzk9xB30FV/vsvb0VZP7e9J6b68qU2RZr94koopy0WrshyAqZ4LRYMOStNKlfi/HaUxH07tOiaN9+NBgY55GQLndGZd/rUOq12X2+Fy8miC3H3D621O71cbwoJ23rRBFy4C2lKfmw9nVq9fWPsey+D4UYYSggDLkr76KYve8LyBwHRWlYLVmwVqUqpvS4y80lNK1ndERxWixWu81ud6aVW6OaBe4Q2a4LceMQNOYYbUkICYF+trUYIyuZ2W2wmtp5MlnNaMho5BfAY9g95RaQEPJJ2fB4STjMX4NMJQipKRXpcIACrSbTe7oWRCBIzNN3EqEUoHSKIJbmpj2P1VcsaJsHLaRth8UiCFG2qrqXdt3b2KZ6fOY0aevJBMedtfdi9veVHD0LpUl3pdmibVTmJSXcZFOSThYHRen4abte4SemUxmnemPQ4b6MFDfGR04EHfDF7/mU9aAjyRl0410YpLtc4ro+u3i9z37TJ17eR7snkvuZ21PPvGsj20NF184wcJaD9h2qJxhvD4083xfpG3e5gq986liL8bFnKc2/W3c1ONjhxKTrlM1m71GsC2Z+HxlDDvKONYVpEWE0mHS4rFYVTZpn5UuUxM9wt8xv0VQNeNRRNxCZ2eqWuS4YjStS/SlJ2kYtcQzTv/CiRZL0Z9Gt/oSVK3fulIxFRZJRkgBuf9peVzy8+sStE3sdd+FpWTWiMWgXHUrvDLr6/3t8bhbzi3r+6gJRes1cPvBgY9uIE4PKasy2wS0v4Sf7w2H94e4dk0dE8pAsKWfUXLPZXjqzrsY0qRcgMvLZkqwoXqvHyGWbUgSCwEqyTOBAP2WXKAd2Yq9YPqjIspwX4MYXV4tefH4BnnuaVSbvshdg9LDXJO/C1B4wHdjRdPGbB6RaKUUtmWQTaP46PWZ0S+uduwMHzppptXkG1n02hXyaz18QRkefL7JJRuuy/A4+Tr6wBpvwmgsB2vlwik9m4FGlUGpevmwZVMomeZcErKcaLMHizojLXp0qaiZBOltSFBjtPEVRRTajsWdGTX9K4FQdG6B2+fIPMPJfMDZv+pu00Vr/X9F/RbHRsf6/ofh5heu01WaFialhj5Fn6b6S6WYh/AgW+p5dS++7vcas3bDM6IGZFAOnJeKyt0dWKneK8tzC8EnAs3Z71on8B98HhR7H6Pb2eIcs1Aqy41N8ytTJu16R1MDSoXEzh8YBLC6Jv1VzCioHpC2LMAbD0F/7qTp3eORfjUMlfWw/FbJY3m/2LobJJzQ3d0r+n4mO/vb74w+SLuRAnCt74Fv2bcDmYvs2QdSNHfafesS7FTHDA8T53z49/qO8IOrBySUhYcQoYz23e4JhgHCl3hCXoNcHLHqrb/tyR+h36T9WSORxc6KLxeKi8mvhZfsgRpct+qyPrtkQPySj9gupqz28R4tYVtf6W20cU7ouySIEMiD6hr4vogH9r5u8txUKn2DxDVCMxl2yrMiq5U6vpMiKcswuwXoWo2nK2RkAv7QyUzpF9PfDYdvryjZt+f+CmHDygjgxIREACGGC8AkHAtbvTzBoLFPJJIRhQIBN1QqDq0Qgo9JZDSIHQA3HMAA/MKsNvsNXBstKAAlgAwpvKtACrMeM5BSwRB7gBPgNsMww/HRRYDiEhhJZABmAAsTADBSNdqAZzMWMxA2sEFeAY/AFYDb/24lSwnw9ZaSsmJ0ioU4PNED0mNmqZSt4VNkyYOLpzgo8YQ9MMrllxhEmow1M2j7pPBsW2NNGU4xDxKzgZ5rTIJhWg7GNstoIPxzly5EHbsatJz8nj3iqU+w8w8mozTxOQ7LVJEH9+0GQpVFMytHU6v15irDL507fGbOX+2bOXLqDR75bIBfSkT+8U5invXezRq61kNzn8lzXMFNwgyUldyZXKGNOgpeC+SzdvwCuniRZilRp0mXIlCVbjlx5AA==")
+      format("woff2"),
+    url("data:font/woff;charset=utf-8;base64,d09GRgABAAAAAAoAAA0AAAAAD2QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABGRlRNAAAJ5AAAABoAAAAckGdS60dERUYAAAnEAAAAHgAAAB4AKQAWT1MvMgAAAZgAAAA9AAAAVlatY0BjbWFwAAAB9AAAAFIAAAFKGLshoWdhc3AAAAm8AAAACAAAAAj//wADZ2x5ZgAAAmwAAAXPAAAJAA0yZKdoZWFkAAABMAAAACwAAAA2HeJw4GhoZWEAAAFcAAAAHAAAACQIXwQEaG10eAAAAdgAAAAaAAAAKAxnAQRsb2NhAAACSAAAACIAAAAiEWAOdG1heHAAAAF4AAAAHwAAACABJQCUbmFtZQAACDwAAAFOAAAClCsOb6Jwb3N0AAAJjAAAADAAAABCAUMA/3jaY2BkYGAA4s1h16Ti+W2+MnCzMIDA3cSpH5FpFkYWkEoOBiYQDwAjxglGeNpjYGRgYGEAghgQ+f8/CyMDIwMqYAEANjACbnjaY2BkYGAQYOhg4GYAASYg5gJCBob/YD4DABg/AboAeNpjYGRhYJzAwMrAwNTJdIaBgaEfQjO+ZjBi5ACKMrAyM2AFAWmuKQwODI4MviwgbgwLI1gYTAIAlkYHoQAAAHjaY2GAABYoBgITIE4HQkaoFIhOBwATVQF4AAB42mNgYGBmgGAZBkYGEHAB8hjBfBYGDSDNBqQZGZiALN///8EqHEH0/0NQ9UDAyMYA5zCCVDIxoAJGBsKAmYWVjZ2Dk4ubh5ePn2HIAQAdCQeQAAAAAAAAAAAAAABKAK4BFgFiAcgCFgKYAsgDAgNQBB4ENgSAAAB42nVWXWgcVRQ+596Z2dlks81k/5JNdjez2+w03U0y3ZndbZI2TRpLEtukpdVqK6QEZfZFahubgCilrZW+CIJQwRV8qBX6AwqKUIRU9KGFugM++FpbjPRNRBDxITvxzGYTtzW54f7MzLk333fOd85d4ADgFYD/Ay3QBWkA9KMnjpFwodiPmt4TjmA4V/SiJ4KSR8dwAjGU96LOP2yalXC0TzvApNmmldOYQFM9qeKl6lcz550KmV0LXCk7FaeCJr7peXtk3yRnU+Njb0nFvm6n0t2NF9mMa9ndj6ZraReLaKBJcECgfo4wvQ9eiMMAjBEqaRumQkZE0Xkyg8m0pozgMBYL4UhI8aPWkx7AEcybaa0YdwnoWuOLUNCF/lnTgcM3bnz6ne/wyWAUMRr85u/mdo5hH74jxNTxqSPP739pFl+e+ZyekumBHeOF4Xw/eyQPjn17EZecUmcQI8HoA9nbIlS7/D7JJ3Spe6+dPHVzz/jBB8s/TFwXY2rnoaxxtGN8x8JzY6c1kIHocJvoiNAMCkQgBinYBxPEJzeMoVSoNga2WGOulzgUFYpDKp8KqdRTxE2h6OgY7EBVUXUET59Rcrst9Zklt9PCsNzuQB8OYikzhDiUKVmOXbKyg4iDWWZXDWYzwypZuDGsAlkxOzvILGpsMFs1aCezNecvp8JK63ExKS42tEEUkrCTeCR7sY5JrWNFsw6NQhYpavtqsydS5GXTKTvWGhxurs0rFW6uVHBb8wuzS1OLi7bYvX1xcWqJ2/StaqzDJdsVO40taFTL+Kfv2Km7UwsLU2Kih8a7ABIQPF4meJ2EagDyMFzTTFpDkkE6pamNEDVzAHWNVJQnN9awul8IcM33as33qlKLAL8qSE5F8goeD3fKdTRWlpBzvCUP7b9c/ZU0GwshVMtW9GvbWRvccLAvZQ8aksDYGs01uszkHkmMX75c/dhEC8urEI6hA1imADCXBfANLl2klX5iYWpb8dA2ocE/QsJse2Tx/5hvy0Pj721AZrcY3xJj6lmIbmsGBBToDwLk6RRkwCBPj8NBOAavwKubqoGw7a3JQQzG1mRR82xeD20xiy4lI6Tnn5k1OscIpXT+Qc657pzVRxFHdR7TRxkb1av38UXn9lqv3vfkBucbO481PlETkPasLDec4ewOX73t3DpLIx7H+/Pzv83PL9fG+Y21uxkY+aFEOVCmnO4E6CHGiupifDo4LvO64LlJorCcytPCtxlYJRzKVtdDBPSeznbPP0/nv0vVIgEQoORRVDpN/e/8XKEY4PR/AyrX70l9OZ7HYq/zxZzzqLeItGQ/q4b8xo+a87tzb5qdm2Zz7Te/x+XeAs7R1+oSWWkqfuKcR9V5tJ7Xa5x8FFkN+iiSQYmK7AhGqHrqEVKfR+WbR9dVHlrZsQyyyd624LSoah8z6wlOb5Ht7IKayaj9vcHmVOgJlSnbrfqNjnC1WjXq2Q6eDc259XMGjsNrsABXNtOap1YTsR9TaU9aI3T5EaS0ybhmUjjijtvoEqM5RLQMcqNBG2urfEE0C8VC0Y8BnV7HyYTM+pHrGSzsc6twmLbQEa466WSyydFVGJS20OPKMvvFN2Ikk52BaH+Lv6k93CQ3t0XEVr/fm1DU9niLPGAKMdknJ48Y0s7XJ7MnupNJrF5Kx5va4rv+oByWmUDNx/YwLsitbXFv0hD9gjZHOSmKbYWEyIWhXi6R1bNiPlMDxGNOVyhADlLCU7o4dDohC9jhzx/ZlT68c0/GL8mJveEuxcuPnvAFvKFAUon+pOhRrzywmx0XUY53NHvbW7QhZ87nTyT3xw9lBK8gRFtxW4uAPlGUSTSuXh+SbrZTlKCHqhT9Togw6H68CpN4B+9MPux+jDDh0MMEPFXbeiALOVJ3YwDpfqcb3u1KSjHyqXy96yJ5WlXqhcNuUIljl927yi65rYxW65kLq7BauxEFaKxopdoNV3Lqs+VaUs2uWPAvoI3FAQB42oWQvVLCQBSFTyDgADMWOlpvZaESfkpKC9JZUFAbwoafSbKZZGHAZ7D2ASytfQwfwMonsLb2JN6KGSU7yX577t2zZwPgDJ9w8Ptc4FbYQQtT4RpOkAnXqT8Ju+RX4QY6eBduUv8SbuPGuRfu4Nx5oYPjtri6rtxKdpjhTriGUzwI16nvhF3ys3ADl3gTblL/EG4z8bdwB1fOI3xopHxzBLCc51CYYc+vj5hzhmWl54CvU50HVs/VbK/8eJ8traacwDBDFyuEpBQFJbPrrkKTEifcu8CGXkHpMdGLTRwc3fV/dVrlKVgtawoDeOhT1nmxMqkaeP1jDn/fusCWeYdULSKuI/YYuimMK5+yO+YwVLKqtqYSUvcO/lCxXQytjVSUm0SNTWp1HBuV5WatQ8vmZXVGhhF6HNGBu1flTthmbTbq9SIx8EKT4AcOUnTlAAB42mNgYoAALjDJyIAOBMCiTAwqDKoMagzqDBoMmgxaDNoMOgy6DHoM+gwGAB/iAkMAAAAB//8AAgABAAAADAAAABYAAAACAAEAAwAPAAEABAAAAAIAAAAAeNpjYGBgZACCq0vUOUD03cSpH2E0AEPPBzIAAA==")
+      format("woff"),
+    url("mox-icons.ttf") format("truetype");
+  font-weight: normal;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "Karmilla";
+  src: url("data:font/woff2;charset=utf-8;base64,d09GMgABAAAAACtMABAAAAAAaWAAACrrAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP0ZGVE0cGh4biCAcgQIGYACIAhEICoGMfO80C4VIAAE2AiQDiwwEIAWOdAeQPgwHG7hWNWybRsGD7oBA1p9XWkRRtzipZYxE2MzJiZ39/yckJ0OU4IRE07q9bxCxHVLIUiUWqpDY7cqq0IXEsqB11VrBsG9IELbZ+f7+NupgDR9RiUrDp7rJTqr5dJsInk/MB7ceDT2aLqOEVipkw9QakAa3Bv67UqHx8GYNM0HzpRZ7L5Y2e/Fc4f1E03Mwjh2Emrrw/98aet+fCQBPkDZImzI7ZE8KVVVPhWEhERXJ1LYKVVV3eH5uvTFKDmGYlCC0jB70gMVf5B+rYmMbkQM2QGpU23EepQ12YJ1oo2iT2hc2PH0cQr7dP3ecSt0CHAtFvHNtJiGIeW/7/3/T9e6kWbk3AW/gpJj7kyYDDG0KwzlZl3nlbwb+TDQtLiOorHzufu2CRpOlvdsswiOGRWC85dPhB+AdCdO7b/IAPB7QAGXk3bSp5iyT7qdQvwQTEGyKrdhuDW8KFUDAH/vNhiWSl8KR8WZra3UpL6Ii3x4irmLO2k1zFMeBAfLzd0CBen9pSxAYZoPujntQU1qAzwbmOdcu8kQDAGK9NNtU8bmSoDxFOnbn0rI2t4rJzdSF4x+M6MH/7091fTf2a6Sy4hJYJ0dFXAnWni5Lh+nrvve/9P7zi46Vr8j6skOqHVDBEFLkwAf5xAoXkEYOEBVp4h1xa5eJzp55b7duOEx7l61Xy5p7dqa7625qSR+yIibhdiXS3eZiu/szKSe3R0iWwnjqFSFKjMSobBzWYTXCanb7epsk7T3T45IiMgQJIhIkSLB2d7+XN2wbGWaSz7EcxLMmXB+amBSh258FegZAAQQctr8KuwJ64fn6VRtrALx/cn0A+PRCQRBANlAKwBBSKgQesJI1zaSPRMzil5l8YHfsFUMecMYcfk6ccUgdfaMwD1gfrAa/yacj1yr67W2Gr1iFc1777KvfzRHSrMy13GpiOVU2p2Vd2bXd3r093Uu91Zd92+9njfQ8/ws/6klPe2VXz5oRO2IFcQKsE7SdSLYg3Yx8AMGkUw54mxbnTbw7WG+gzZAHKJuhDtBXxx3gD4g3IxlKugHZAIVin7813aCItizWujjbR8iPhDfKryAZqw+n9jsImuxBRKZMzD1lOoIKpg9NC3lOKNNDDYNoy6OfBYcXye+DuLPCI8HHYsHcCPePuBG4p9chW5p8JYqSYjuaRPh6qyrDOwNEewcKUAVNPIi+Mm48PH8EwbaEcmYRFpRAgACS7RDbGY48cWnrx9ctdFMwZXYi3kVUvhBaHHlhKABUoB2ePjuchUkGLvCADwIQTl+0PvGCSFYn3Qply5MvTQHNzRlRTeyNPuRMHvIEK0EkFVuIA3RFYFbYZkmTO0FyQQ5h+iZYQpiJmx37QyOHmv+IN1jrEKzcApKVFGbtRo4IA9nGioamJjSiFxBAZJiHfGgAKdw4vSqWZEi67cDQFfStWHYBAINsGs1fcuUP2a8A6ZZlFjQ5K4O8TOgaRN+NOQMAbUAleiTaYjjBDDIVgDluwvQQ7PmPC8zIpuk1BGgNIWgPmdH7wiOJiMCcYaKxYgwsM4iRzWQFBhQsbHPgUJgXKBDv1XBWe8AOhM68R86damONWmzJJot63MFJREUpR3r44UGwkA0egCOqgJxVCh/SHLKUBdjDugDXw/1rSTjfvdgXgJ++1PwT6TxPfVxYBHAWvgvdqpnjM+WnqjD6VuPQATPA7aqaF/8SqdvfBnM9ATgDx4KIKtv86S+9dtprwBHH/W3EB//5ZXn2c3qr209VW338tep014hX3vmGSdNmT9W9i4ppdInlVdQTvdyHffLQ/fniUBdawniYCg/waDMr+QIEtraDHrrniZ425JlPvpqGx+Id/0QkNvgww01GCje4+UlfZjRf87OOdatvwze4BMOholB+nLH/Kpp+BSRnGvakJzzmIfvd7x53u8ud9tlrt13ucLvb3OwG17nGVa6wzWbpyhQpkC9PlgzpUmbx/9//f3PGT/0p/539O+uHv0jhAjlzfN+Lzc/JZQBV3vJyuPMDi1Yyt8eBRBsTU6pIj/vXuw3y1MVvvijJCgBCMIJiOMEjKZph+QKhSMxJpDK5QqlSa7Q6vcFoMs8rbM/N4XS5PV4fHIFEoTFYHJ5AJE0xqBuvM5gsNofL4wuEIrFEKpN7Owy5iFHJc12nRYd2nZZaYpkVVllptTXWWWu9DTbabJMtttlqhytVlw1qbwhfkyFtNkfoAM5p8HIm7HOsG7bLlYrN/HPDheSEArWmvA01tLADhx4GANyZJEDbFoOOOa0Jx0M/5aXyLVasXIVKZarVAJzXpFmje8GHLDNEQLFsQIshACiZBgegvQDYa0CbgLw/wEQOthX+Kq3vJhuvZ3+4GDJuA1SNlCd6GQfvg7+e1CRahSZ2WxKlVA2MWgaq5lVsVD1DY8FiBKwgxrFajjIYLhrvguNmM325UAE+MA/Y7HSwbj2aT5ZCzD9Od2lopO5CiD8fLu8SmGHlHAnl3hlUs1nvPL3qpJ9vQnM8oBtomJM0OsBNGL5sFnJIbzoxmEnUQOWAkSsWF80r8eZ6T3zSQdI2+6fADshkWHaUptHSatBhG9fRFVadA5wnNQ9ENEcCXRE28YsI6WmRwoKbwcRIMxCk9u0FAhPRFsQt6qsLipTm/2OPsWIkQnrapbl/8dImOiKxutt3ekqUKFE8VnfQkQ4+K0Bg3rKwLm6sWaL1krZJEzbt0gPDi5AF3zNQ/HQfmkMRLc+UHh4WlWJQpau9gnPa4iipP1IOOSpsQVsR36opRoPPvEI7CByfM4QwBHIEtA5DHSkgFgQCQ8mElr3Z5ejRHafQqxU8TxQu7BtUuacvBV51juaj7T1InPNxc/21zwft2LLYTci/aw1u/6yvKg5hRMAV5SJSL3wn8JRU+pZ7xznQrl3UYhW5uceVYmL3+UnRAjkFsxd2siV7CElcdeNioOSDbUYMGQICQbBT7/IKjt93/PUmZpIlLtK+oDz9gH8Hlb4bLohehi6a6UVWNIWKMH5lpEoqBK129VER6EB9U4xwmgE/fobZDr8aMBozQBsqtGB/RKCd8ZaVN1DPIAF2KcVyGhGpzS9TfenyUGxJBrueOY2aNRGLaFCIL7MG2+XZfMwnwOSHYLRnq6BLvLLEBYCiqt7SKfQSlzuO51PEIN7AjyNeQ3SIQDf2gbcOXBWxrh7tHKIxbmdkzymbWg65HEvA71laZWzO9Fy55XKM8CgYu/l4ve0MkkFRtb73oKD1cXen/lojM/O5693uIhzyTnU4Dzq8znCgXxkQc+W9UEe1GQsjoXurcfHuG0gYUt2KWTQLpSbmKGtRF8mRF2lpdRhRefcFXM9ixOt43tiCH2y21gmuWSBHhdGnVpU+YnzWLYIICyv22zg1GZjzxdyLh7XnAxLIQMtIxqgIYwm1cWtZ4de+KyHwzkOMDMuwqWIuZqcyjJvG4DhZGVNXMqWYHZPW3Fpi3soJcHLc/Fu6AossMrAvYp8eR1fKkAQm2aE67enlTXgGWvCPzzOYRYNqEcUr02YVFS0DAyIS37Nv9ZaOMGMvEFaSYRHG0TLuIr5MU0aIWbMsmomzJ9ukzHrB2VKcXRMlRzNLGZNKra/lMTCWVXY5JFlFGUtYxLCIHN6iH1EgUFyo0mjFCkyryWr8LLpKW99zbzDU6hj2GpLSfvNTbnuC6XQTeZG5bN+ZY5we+pzN274PBF97C9lsuA8UFkxbdJbcfdbT87kwagvQYc5T5D9oGfCEE5hb1cCmpPNHVfI0s/NuBsaiwYJe6hro6j63tqJJmyLiLi/oWav+m7eziEhuPcn7BxZxoDnEC481AHHlTJgxNzKZpAabZOBz1+i9w9m+q5vpwePMihy+GV2pbqqpEh2siGdQW1j9ct0aYTvgCWo+dpN4jI/ugXSB2a40FtyjxNkbmivoNkJRET6bF6lVadCh7bYh2Hu/Vnzr48JWzTBE94aW0Ktd1sDJIsj58lL3lcArSXzLO+QNyOlqMkZn6NdtA01zSGL2H19HpZk0lxGVJKGIi5tZuS67erQwnpFm+r47eYad0BySHGxeZcxx9RyA3usXxb61vzpFTBAjO2Mt+gDNa2CdMwePcfYQMXR3s6Blghu20hNMt2t/MWky2aMfZsnio4Yv7yi6kTl9KW7UJmC1ACSP1oxWyYjrzRKmTqv/laa83Tn/VPoLw42ZCUwDuc98QYeLVPQoaGaSXW/vYhIXMvfXH1wm9EeGcsgwZq2h2/rWc/BzkiV+5t1VmYNuMWwhDzS6qKjkSMFGwUmVT8cOedfPiq7yXJiFY4/voCZKPnn5jUq3a/tN571+J7Z4u9L9Vt9xj17b+qxcSDUmeUcwvCHEsJSsXD0VymDkGlgfgN/hJUcK9dD+HROZJ8txU+45YrQN8VMF7mosQNRjV4D3qYjicymOxjxFmZdfval5oqu8J7Otx/MnycivXxD6afdS0GaT5d6R9LnZ07iYKvl0JWeI76d9M/1915Ar1Eddb2UOJ9eqbNTRtAGOpXalV6VToItXtr9OtN7a83DLzQ0WsxiWwSxoSEMqtSq9KrWrzalRF1ud6LSi4RJmSb31bZe3PdGu0GhNidNgeYPlbZe3PN7zcG+4nDrWZld6WXoV6ME7W28tXlrsovceN5qp2T6+BACzhYGWuJUm06U2Nb6sdEqEKfvIzI274wLceZOWNFyWSiCKYkp6OotbcaINOpVLLK5WYU5H5Ra1khNP24S/6ISO7O8J3/irXN0W4xCqAnfccbByHRfZLpdoEORod2lQTIf+wSPdYKseD7i8zPdc7BJYLyL3mXizvbKPvq5iWMVgAPe4w8KDxwPOrkc1vmciytvD5gwXxZm2JvnwystRe9pV+zmPqFYaNIShJ5bU14ymehsGFdZ5ubR4cT181edyKSkzdS9AVX6BlTQzaL0XMFgldVg6v2ELdERJocx2VKZdjHnlZqPEsa/8ylcmNe7zQp/76/n8PJnLicKigLzqNCXXX7v3t3yQwKSuKq++XxXIK3NBD1mW6nWDOfV3TOm0/WcNwAHO0s2arMbj7W6VjgaMu1KyZcdzVNbWnXFUmgnv/TDJ58tS16v1PRxSpHDDYCKW5S+N726a5AmH1ZA4rulU8E9HnpOoaCVomOxoRpQBzzwQxNDnh0eWYTkIdpZAa0NEmyXguTfcKyzTC1mLzGiI2CLWPFLq8m19j3QtsX1m49aF0nfGDvkgaAItty5dBntp89ggj8uC9/42t6Ge6mTSvr6WrfyrGR+dGxo/zgYmdGnKcrfj44Gd/G/dnP28Y2XS9Rk4Hk4rR9LO2q/ja+1axgOykoyrs/lp10y6ID1WV39mHXvPrAPradA8JrOhQKuzSE7kKq1K00SsglbbqR9cJz6lUStOtWQkMoWWCoENkY2CVX88MB2ly1zjn7zGJfy3fxWt9MbwZfDRxGA00+k5VEYjjWlUxcfFK2PjYh37uV2G5N7ZUXR6C66OiqIymixuxOYtqgR3FYHNJP6O0A9h2kA6kkJg4/zw7qmrNOLqzI6MlUq6zO4Jk8BJyuDtTuOVsAQin02txGR0xV86aqSKC+3i4I9uX3/ZO1+Thlv2qCc95AsH5OxgfXnWT6/ftadJLdY8GNPcV0uawRXdpbpZLdHcn9cDtbgJ7EYa/IyZkTNMiVibRjAW+UnEh+B0NZNLIHjy7k3izbvwZllAstmjwHexcghNvrhr5DrwgVAwCcYFPm9UCApghjn2571hsMFU1x3f7fK6/q+k6rlXebXb5L/TPwFAVyLB2glXwnZyJ4BOai7thCKfh9lqWx6W4iMKxWNL6GHJIvPkxaLTJenr2BLIuSr8y8tF4Osdba7vPhorgVepvbk0S811lxLbmQQNLZFHTQqj8mJUxAQ93fcC14ZbxDlcoQI7K7fnQrlrWWtJCdSeyZ6JQNB3rWRDr3OYguqAGogJSTdKj5SXXihPFcFcnuNqdxyLA3ruodQDqhXVkQQLmZa7uSBvtzFLpW/p92k7sJifqbBiWG8dT86jEQrpeAMdD84baO7orCB/DhPcTqiISWWUy27UqVkRUDJhhkXsRCMnMBtlbzp0rEQOq23WKAOnSonfIMXQf25+88Dl0BKqy35WXEpyXC0vBjiZMDK0NUXU8W8TNBqdXpIv4DkSiRmfpTFXFuFmcFTwpoI8ociYuYZaSEM7dAGdnAfE83ieCg/bTw1yFNMLxXq0Dmum3W+5X8PGj5Lix8DaIxAdop0m0UlAHX+Ok8z/sAMXXFtwE/wfbUTJ+Ja0bMl5fQopAgNt6Zi7yT/Ejx2UtIiQGy9nvtQPRTiEuEdMjyUu5MfHK1T0yExuYg4+EOM3Z3LRk5SSbevauA3R7zWagDtHjuLuNRS+Ia48gF9jzNuecKgjUiOPriSWVa8SojH4kLmn/elKNUNT1yjDQhQa+GRQ3TZwI7d8j9zC2zQylB4JtIYpTZaCEhUHn+wlJ0cY9P6bE95OQNRHKmIMYcOd+evjoBgtIRq7Hgw26cq08zh8VBwfioXT66bkHVKGkI0XaBqLppb2B6/qASWGzr4+976+zqNGdkhWZnlrdnZFc0YW0BjqoIg7nkTP+xGkOlBhqIJChpwhZ1cYTGQvKv68fm9Az94qel68H57hhOPsKe14ld4ipopSlGab4hFT0TjQb5gbORc2wq6RrrARaA2wEQZEtlyylL2ISwopPx57Gj4NDhu8HD1zZzl7SdI+ez57xTGCfsiRlG6EwT3Dnd6h3nwjbPHgYOTwCVvYCM4Yor9+g41i7DTNCAimstVdSat2lJev7Nq8ZWXXbfI+Xd1XnWlfmukrWGXIyTiQk5ZR8QU2XkvEE/BFBAhf8R3wVhQGCrDiYEIpYvkW7Mqu8rLVXVvqM7dK501dKkCLjxTX//13LuSmcGb2F6VtB58hYOPjLL3u+X0KFSogE4jt30D/Y5SsOIkYxVrzvjaQMI8NLytPvVWfgVCyEoX4FhjLs59e/FlOMKUtX341S2xFBxaGCehGGBx2A/xlWC4WsZaKWOLl8PLimpLH1SXFy0GFoR81gOI9NXBHDEBnWGuz/mrkusG9NqIRA695ecdy3iUDSE49+L3nu2ok+ik2pR9sAdbDeJBu6Fm4a6HiRaEZx+xpIaCSs15mmVFvUv6tGdAOXyKXHCwhXwKBw7D9eW8OOKy7+Rdkzj97+Ql7+eLifw3/gvQMKAMgV8ycrFf/owftkXhR+nigKM/oFB0g0UjkEZAVjJYWsWWCaozXepJTOHl2Ft5nkTQtjssF/atDuEcWN78ob5WEMkOUDrzoXphlzqAicGwCm61PTt3BUQPxhEZoh4MtBzd74dgpfzE1RfVhyawspVBW1fKmsgGsWT2L3YubAecwgoJkZW0vSpuOLiOx1TvgVD2b7sYmslhgRoRmpjDZhpLBZqtKml+XNg2mbrDLp9ApyrLMbI8EMlcxXQGYOtvZXgVoqiZK08PugaNgGoVFSMsBpXYnBrq/90vZmJeylqglJ8VZssRIWgCWlZfKiz2E+ekUKT5GZMVgmGsLJhuEBLRPN5Mb1aunhs0Hnmc9PhQn4HITcBmJhJwEIuhvCNHkC5T5aie2EwlHKqOlyV7CvTDIfAo/g+3YfUF9oVeDroKm78u7elqc5wV7tUjcj3omUryR0Gvw5eeXwfQZto+eyXt8YDRADbQ9tZeyryY4vTCRh/UJLCwTKhrPETTi8Wn7UpoaIZyCn0JAOnrn3ea7Jq6U1Swu7aPyr4vSxbmeFFUbTbWTpGpjqMCelcH84xUtLyubj6AhH3gQP7idn9LNURto1AWyJAYFrGT4C49XNr+saBGnBUlQrKhB9ulOjrpbkBLL9aQespcRGAzgt74Auf9P+Bks99LIFqxFMh8Bxp9a0i4VZR7LGqcLY2AKT6S4n8PFpWdyT2XyzQhMVygwg4hOMF2Tu1V4K4BypsCPPC+E0OPly8KyGtgNq7GrfWiQzxDoVYam5yWnSpShcMBiPZ6jQbA+wc9gkDWypHVpq+TkiOjkCNCMFFUU6Aj6TEM1e8MIK5edzWZuHgFvVM0DNQOqgfcDH1TN/bX9qkMfgHlrPMr/MtPm1vkR8dIKfQXnAHYelc4qug1gR4UTrhA3RzEXVwjWBceIFclYPp10b1KORs52YDrMNguU9RSEFsST6Fg+Vy6MA9p3cAYMzoXHCeXc93afkgWabY9Ey7uF1MT9pCcrxDFgk5NP2aGFeXTPhihn/+Y+z0z2/BSve7lgyYT9JGHAEmruoZhDGRDtcNgVGd+CyWMqSSRXX3RwjixGlquR58goEoYNDdB+r2CsQD0zaig8SiOjPxht5/ND8v64HnA9+G3A2/InAU+C5ubg75cLBgfduvksWTp4aUnHVn7lnj2V1UL2MlSBcoFUIKurAVzCl45xhYxHZIsd7dxjIf4yokjnhqZACh6Dk794MM8I9u4StJyn5wuWnU88f7gUwJ1mfwm1b4rBZ5QfoOTvZe6L2ruGxiStWx4azJ4ZrN4JgJfForPALK95X/TqyXrwaTpdP3/IP8we6+EeNcvCiRb4VcUB7og9UqCVSvFS7netBkTD7uP3of/wvOrsmux5/RvW3w/iu4W1nw/cjUDd3+l8ZL3vXuQil1OUdy5UcJXbGcmWw4HLPTBMxcpZPuWFFnBBWw5dP/8sW1+kaAeOI0lnheNQJMGreooT8kMgxN5NNz/H4STelMUrf9wp40HaeI0SJ+CFCp8Sx9JuCnmnAXaRGIbkVXkixKJSDUYOwE7fCH+L/spp58xpwaj/5Gt5diHy/Tr9xwADzUdjgS2bNa3l9U1a3TWESRpJI7pLtZTZ8YUGLGKk3/7vmP2N888jCYRJqBCTaJJGfERpq3WULe8n6W1Ciry/X2htJlnT9FWEW+imUo/ftP1Q3a86UdR36UaE3iWxJGimfRF9FWibDPxXJdnOsrHw7bXHnmKoHICbDs5AVLC1rfdn7X71HkCpJx65OfKzqpd7fZRFjPoMYbW3+2yXXpaGRtgwtMUTvbj9yQgLapN5gCU/ozSKdV1AYQdBtIlNht1c7thdB3aTpl3kVwd+v6jdp921A9Fe6N0Hspiy/dKzTvubGd717TIvTDyx2Ejg85ArcFW+mdEYLBbkZGOdvzwbmUqZ4+PeV5wjiWGVnQS9qWzozYYeuZRxivkdFQfYlDndF2fKFiZaL9UymtiZJVE6YkjEJTdbfiIcsLLGwg4jY2fpYXpz7PuFEuXgP0buRGFwurUMegpPISRNXYojkZzYTmpl/rHVkpvA3UWL9RnXqd/naa99uHT+9vv2OZ40QiEMTU5BG/UmpSO90G/nNo/Yi88f7z38sOXW+74KmKydF4IBX6/SkXri/VTlx/lraoXeHsQ8prrcFB+83HcqcL1O/XGYqlnxmyxhkNRQbkzCeJU4CQjYwtJ7rfm47QoWd3xz5y6spjcnW1v22oQQeBfRiDBbFQ+tL997I85Ybl0VK/NIJCWbeMcMSv31OUuHRx/y324dfTZYuK+oXt0vQ7Jy/RTiPawaQg1kr4fdi7cICILey033TppF0CegO6qi7ObUF9LpM2s8Jlrhmf7qEMimcZH3gSTg9iIVgro/ZlgYRAwLdVgarXNxFbi4UBa4gsgDSp7/8PVvXakhc/quO9gNAyukGe+aKChHRWPch/u0bf+/j8klBZMvVjy7pn4EvFp/xTLIR3eo8s6J3K4CCo+/QdfnFAQZQTEYcuXMlzGfOzaZMYf/z7GDY9IV5DAe4xVEDPHbDfv6eGBlXYp8O598fRceDbGpnxmOfEISrbJncp6OCEXOs7ZaRP87G2mnlNOFQGbYGnYY8rIjaEKVloX56Cqtwzf9zP9DE0Q8hv9U6NhubgwzAayFiHQi6PK9aFhmZ1h2sWgpSt5019a/Y8tCxyGbr7gF7FMhYaCTqqMN8Dk0LgOV5sgIYf9roAYpReasIv7JIlU9jcpwyHNWzWUB5Mu8OXLe3K2nFUVyOqbD8zxFmcStzrxel57KQUBcXJ2IHCUWLxwOSEhCU7mYVGIc6PPozSXmbmFvISVQ93zc8wEDjvk9Cs0syTzRUHnKoJGwYknxVSKeiUOBt7uESCioj2XfSl8imqSOJUjI4MrolQt8I+XhP/DiwJqBEoUxT8heiyNmvpLHXAsiWDEV/E3F+eCM3PWkUjJkpHTj02j69AKoF/Ca16KvD9Ma8qUFn/MI+jhxVipoAuR/yLLVfHES0+Y95a832sXCfo0QBmgUqkcnqeXen5K42L1XIyt292MNfR2pL9EmaJcdEvs67NmvIxgXYtqc+eZGldMypY5k4+0ifpbOJnHlR0P7eR+R3NzrEUyS1lZA44a8W7G0gP2MlxWvxr/HtQv/YkL7HRjtxSNNNu9KF/kmwnuzcRERxPoX48hyB7SuxxVfnu2F0o3NIn/gG6rntw5Ug1v0t1lKbcnXFZA/HFZqd1zfa1rQTnr9T6LNSsnfQPm+DQ86AWGAy7mt9PYwgAGuyhPpPgJBAZvPmDkFs3Dg0S9UXBnqEO2ycMyIreSH7ziQppGnH1TJPUPsEAb603flHpRjOwbaMbnXc32aJ2yaQEaZyjhCZ1rQik+eL0Gxfq9mJWJScevkLxcNPuCmsH3hlPMlhNxnnMIC6NMQAjeBneUj/DUM2MrdmiyCcQ1DcznnZxFAK6gbA2cNSZPd0do8vVHDkYWmKHdMsBnDqzlDk8U7VEgkWKYKdhimSHAzAs+3VN9QJLiooBbsxCibJkIrB5VcNwKP7QfZTj+SaN+JsL5VUpTBFmL3zBKjbTeKbIhGa93+Zfokio3d0wuWTb/TmISLvKRik7jVMoqBHBLDVo2hzbXTQ/wsCGwCer8vAjJN3SRTtXrmp72XNP4FlTkd/tE45M0DFyncQVmPrfiAGpC36gr3K9ZW6MEEq1eFg+GBJiS8auJFYYjVaYKFxqtgrYi8gYeQPYuB/vRZvGdLMdwHZOTacooxisJcHxGIBh9hrctFm5eAugukjSC+mRE0aLAagxW2naWNtRhePox3cd2/HKKlFdEKPHDnmWnrIIK+9PARzAHDXCY8LvdBlzTY7Ypadbu7+NIS06gE1pOQ2ydFo4H5vIp6gjpE22xljIwHB0jecFEgjzsbS/GP7sMPoS5CK0KsD+KM/AspwBPxCoAzAAdQVojVAPw6iaIQ4Qg64C+95IwwwvKvPzOCMJoZHa24QywlOMDej0PSgKPf3Fe/jBPW4ZGLCBFmTG/Tfvz75ZhTP/2/GR9j/1x9rbNftkKw+9yDpZ0B1nxa2nn0/Yr8YUqnYTyXb0QmcpoNWNWy5J3z+ByEL/ugI6xAhXFqPk4T7Zpvhy0Sm1wDbW0hlqUrqycZUCLZvT/l5dSY/6ktYrI1RCHBDY7URCdoUPk1uUFawLYBwTZ2uL29KUvNSo+USHfTILJmf5PX0sxIpKlM5qiJtxbxeHBXafW5uEriNv1Ng8h44PzdviY6wEYvVKche/ZhD3Ve9K7dttEdBs5y1+p32aHxiNPtboHKuV+jsG3aj3sAF+DtBbHG/eTWmaabafidoPv/vzJrhO3ntPdwgD5ekRl28W3kanM9RwhB94kmaKuIdj/W3hGaYKlEu3stEZNVK86kUntXfCvhI08pUe7uLdx5RTT2iY602rroxmRmLBcywRTe6p9IO9dRGsZ6zhBPqQmRyIOtJvIzzuThLRN+PtTIsy6lGghA8EyhyezkHlbR3lTbkFpSPSXS3ZXdwXMgomCNRLIaecYO3KkzmQWwp52YDWXyuoHzW4gGWNkViQToNnKgQXQZNak/Z6LSpEFg3YBmeYhZTk1qQmOlSS+tWZqx4IW5eZRZXrOm1q5WfD1EFGw1EbGZU6KRVoj4yGmRGqlNi1qO7L5d29NZzUwmMqujSP9PjUgLDOot//8+Ei1l4OZ9vVcahDNX9ZuxCjm3UFlamtFzk6zIxVazT1azXRrvPHIkO0IwCrAnEOaCGWlwP0Q3r/kuAwIQXP6lmGKP/Q3b7o+LH8x6ujM1VdcDkM5Lg+D/geM/MgEv4OGg7trbRVggP/9IqxQ34VxbJLKlSL0vYVaSaOYSLVq0XLNRTO1BIbe5RcGXfm7ZJ7ZcmDCEFYIrLKIhnBsJ3wSY3OfYAviSEIyJiSUYyyX+GQfnkpB84Ta7EJvEuXl01cF0FW3DaWsL9rcBppvo4kiXlaxNTZe7dMeh626aNsI0gKbtMNXRVYGUf1laJ1ExZo2JndUKqQ8b46AlgS77BGXBDjljbu+LTjzHhiKXSlckiMqFLRJEEQlrJNfK6YKmTNx07UlHi+umrexdekqFrmy/mFTS1m4+KeVZJVH+N6v3cGGAyrxmoccio8DoAxQCmbaeh9VIc7RNQ0SO/cQtt2iB/cUzRnMTb377PDrn8kWwRV4YmEhmG43IRMiEsDaOrMgfgXUbmdseu1yhDlAZkvtmmQMZPFiN8vrBAtq1+ymQG8zAQDCHYy5otm0z6I3AnGFfrl4wVmFA4qk50ybHOwIC9oT13YPStfEDzDv2LVgLWFoKob/YiD2Q+Y6NvsFx23c6qby0EBi0MOrB9SfzCCljPpF3vaJmBJMwu0X6yzWpPLyL/nGlmkaLHBCcnIPr6FJJQwkmxu/oOV+Is4B+ZEg2Wu20uCTAuWHe7ebDxpgf9LBrYHOrz6wxIvQbvhs9xGrbSNDmVeYb3WZu1dgyPRh2GFL0J/OLW1/GiGKoj9XQzcZhfwY13zjbRRzhnTUc3xfEYq8DME3zMHnmr6P+GRa9FuIgeFP7kHfKu5Wyx1hbJ5nyQvJlpGrZGol8taU6eyVCEq7V24dybCyE00UX6o8A/ZnpY8GKi80UC5gFcGm2NHa3kn+5lDhGRLpbHTHS3N6Io2sdIp78VUVSyPEdIpWjJ0UG0I+RbHJT3CM5rHlwZfG5VN4MSORnAGwbsEVE/tRHjFy3JeLYcYcjnrCJkRQqt0CkAt0gMoDejGRTfSEiOdzczm9kLoP3+e27QxLHsCyCjAydCTpLiaFoBeoTBtDWZQbEGKb3gHgVs7eHfyNoDhVnhcFUUUZJmF/KRCbLuhNk0d7agavLKs1eQq9IR6O94RRVq5K4c8p2mtw4cYJ6/bHv7AyBpLJZBR4KprCASeX4LLssVgivMCmmBElediF934m2VQcaWbEpb5ujjiqNxDNlPd1E+oLO3UmjfLHUqUEjsXbeO6YGgN3GbGDV7TlTGc1l0vNYMusFLqXXlX9EXO7yqMFEMxwXLoTeubmfqNEC8SZnrCU0eecH50qKweMa8asmTutNaEc2F8MqgNgwhttihFeI19IyC8lLfKVOE6k9paSA5Jo0UjMRONeptzdtiF3DK/rcZGmMjxydd2bFkmaN/zPFuI6fQySbBil632fjtYt7XNN18LlhOIIreayoxtgR6OSRBtU2UpAzTLdsBNmcDO8/dHwnZ2zTQtmMpZyEDMorlZ2t4AajEpBNGOcThQvR/lsb0JFHcXduRV9i1C1b1hxaK4D2LjhcrZ9LUoxb7QYeYZLqu41e+29trR2C7S7ZLuyiLKyaBXCKWyJXNLl5xOgqoEit22w3iMeGT9Ja17WS6k5ZyMwswLC4s0LFqksjDM9nNuZtHsCia7Ojnsi3tqKqmCe4vgtrpGgTVOZF3UFCwqOTvGYxCBqmhcD0yzm22pm5NgR6JRzzJUDksaJmvHsKA/I5Fv7O5tGYd4LCFtSfAmGsZNe4pHEqNtCLI4SQ5hobrayeoaFWRU0KL3WjhgAjYwL0nvoDD2eLMnOI+sI3w2QmFuf5yQLCBbP3by5M/br+1GC1Tm16tRrW4ak+2+026LI9UmkspXWNzhVX/e26G25Kc8ctQ/ZK99Ey9911T7VOaXl/pmy5cuTZKl8BPX7n35ZBsRKlyixWrlKFbUyqVKvxljvwNTNMy2bv75MOpyuJuT1eHwBCMIJiONHN/YSkaIblC4QiMSfpod1PJlcoVWqNNhwxVG8wmswWq82ehXWc0+X2eH1wBLKnFzAOoTFYHJ5AJJEpVBqdwWSx8xdyefwmpqVCkVgilckVSpVao9XpDUaT2WK12R0cnZxdXN3cPTy9vH18/dSoVadeg8Y6MH1DqO6mbOxc3BKbc3BKbkkvJLxVm/a2O3RaYqllllthpVVezOrwzsdjXYji83EyOfKTQUIjUgZyTW9MuWY+uyXj/NHXKyz6x+ozuV4+3oXroBC24Vz4zbGMVtLFXojxAriiL9aucSM/2zdyA6ZbA67y1ZEEVeCqplbJ1Y0KpwNVvl4toM/HTemnlGGilXRzuGTwRkzC0A2Z4G3gb6Xc7TQ5guD/GtwT3n5l2KhJ7pcJ2/SU5XFR9KHHkMdH8WlOTxTwSUIkr9vDFHoNJXyVxMrbGpCr/HbSwRx6DxV534QUXj4SHCt9UMUPqCPqA7A6oqrWyMoSn2rw6855P/gTWI7h14BVRf+WmNrqIqq+t21ITIk16ZEKexI3CSmBDDmpdAPAJgcrLZuiwdOhpEsPqb2s16P4xXmtJ2LuRH7Kkz+7PoU4z0NvlItz3+gkebpU2JP0J6fAMwlKQFcbHvjYdT5zQOxLjnXrckPTvrfbbfvC4WY0u2VabMTZ3cb8OnBc/PwETnXLGWNbym13xoTCjX1O4uDz6jKfxgZsm8ulQG+LgZgYt1i3K5uPDdlvISf0vRNiqHLLsb/pBgs6AAA=")
+      format("woff2"),
+    url("data:font/woff;charset=utf-8;base64,d09GRgABAAAAADwYABAAAAAAaWQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABGRlRNAAA7/AAAABwAAAAcceBLZkdERUYAADjIAAAAHgAAAB4AJwFpR1BPUwAAOVAAAAKpAAAEIHgKSZhHU1VCAAA46AAAAGcAAACCMLwql09TLzIAAAHkAAAAUQAAAGCELzsEY21hcAAABQQAAAKWAAAEAvp25GVnYXNwAAA4wAAAAAgAAAAI//8ABGdseWYAAApMAAAmcwAARoDeWSqVaGVhZAAAAWwAAAA1AAAANgEBZ9VoaGVhAAABpAAAACAAAAAkBsAEFGhtdHgAAAI4AAACzAAABYzcSEg+bG9jYQAAB6QAAAKlAAACyL/90cxtYXhwAAABxAAAACAAAAAgAbEAsm5hbWUAADDAAAADjAAAB3TpinkHcG9zdAAANEwAAAR0AAAIPqVHWgVwcmVwAAAHnAAAAAcAAAAHaAaMhXjaY2BkYGAA4o5LWWLx/DZfmbqZXwBFGE6JyhqA6Evq7Lr/V/17zVzHvALI5WAAAwBNkgwTAAAAeNpjYGRgYJ76nwVIvvi/6v8R5joGoAgyYEwGAJ82BtoAAQAAAWMAZQAFAEgABAACAAAAAQABAAAAQAAAAAMAAnjaY2BmEmScwMDKwMC0h6mLgYGhB0Iz3mUwYvjFgAQaGBjUORgYnESg/ILKomIGBwYFJSHmqf9ZGBiYpzL8AQozguQY7zGVAikFBiYAoUcN5gAAAHjahVRNSJRRFD33fmVZlmGpk5nQaGVZ+TMzqaVYo0YhoriRSIXSKYIQIgJBIgiSFuHKaGPrQCqkNi1btZYwyYJWUa6KjIoWMZ375n0yTIofHM573/fe9+4979yrh+AeNf4KSAn6pAHlegMJHUOnLqA1mMJ53MMeGcE5olym0aSFKMIbVMggDuAFeRbN2oeYdKFeO3BKexDXWpRpAqe1le8XENHrHHciiS9okjw0y2tUyxJ6yLXyAxXBE7RrG/eMIqUpxPQBRrSBKOD8LuePkJIIMYXNepE8j1TQy29PMawT/H6YfJ+c4rtBdMpP5Okk+jWGouA2tusd1Op+bNFe5tHK/bM4KnvTy/IKxcyzUU4yxjqc0bPcH6CB+bQYSz9zSlCTAe6pwZCcSM9oPBNL8JjxXSCibn2Ke2Nyi/PtaJExRHUI/fIbRfqWAMrkEzbKBySoW5fLZZC5BJyXoJtn7LL4pJ1xfKemc6jQv4jKTRQztlKdwaK9o1bHnE6rIEiQTbu41y6OqzbmWZuIrRJJL5I36DOvWS4Yo06k/zjdsmG6DWNcD1KTXFCzYJC6mWbKf2T4uI2pV4E7uyb9keN801Arucb0Mg4RxTbTKhtOK8LlZveSyyl/1lps/pljfKaDzddj85jd82pM77n7j6S/eXz2+JUBjjC/enJf6FHnE/rUeWXe+SXfczJYYq0ts5YuYZ/zr3kolye8TlkcXHP5peixYc9JzzHzvPluLbZ6ME86nqY3J73W67CrHfOvedPuI6wh+vg/ttoN69bfU8Zz6cWVPML/B6g2vzrvhFo7vbLWhuw1WVlvHjXP5OQW3tOKR8K79bG7OxnFDlfjrG+8RJU8RMShG4XynOddxjsZRan1JHmPRusNWEAVUehRJePEGNcbONbdXFvpwX06ggL2ugHrb7rT98U29kXrrXWs7+asvniFZ3Qg+Q+CS/K7eNq9k2dsjlEUx3/nomaN1njNPoqqXVWqpUZLtVVUW2rvUnvvWbNW7U1tSosIETN84pOIhEREw6uJSBDxRWq9x83rDf0g8c1J7jnPvbnP/SX/8z9AGX6tBojNSIndiXdfVl7YOocelCOcFRznJKc5RwGXuMp1bvGIIj7ymR9STYKlmbSXSImRBBkgmTJTVki2bJJceSJFUiwf5IuoqW+CTAvTwUSaOJNmMsxt88A8My/8gpyaTpAT4kQ7MU6hcyM4QNWyHY55mfmWedHHvMtjXvKJElQCpKmESoRESU9JllTJkjk+5kPLfC1vpES+G5dpZEJMeCnmfct8bpmBjssyo/4wtRj0nt7VO3pbb+o1vaKX9aJe0EIt0PN6Ts/qGT2lJ/S45ukhPaD7dI/u0s2ao0kaq920q4ZrmLq0tlbXClrO89XzzvPWs9az1DPVM+VbqLujO9zd2l3P7Xp1/lXey3iv0rP4v1GGcfiZSt5u86vrpUIwvi/zj3fE91pZ6w8/ylOBilSiMlXwpyrVqE4NAgikJrWoTR1c1KUe9a2zGtKIINvdxgTThKY0I4TmhNKClrSiNW1oSzvCaG9914EIOtKJSDoTRTRd6EoM3ehufdmTWOLoRW/i6UMCiSTRl2T60Z8BpDCQVNJIZxCDyWAIQxnGcEYwklGMZgxjvf6ey3wWWn+vYSNb2UIu29nGDnaxh93sZR8H2M9BDnGYPI5w1E7CMU55nXnGp8V4X91MFhNtnUKmzfNY91utCX9RcCcnmG678ScmMU1SraYzmM1q3vHeTlOi9LcTlSR9vTfyxd9KP1jSJP13I5IlxeujRcxkMQtYyjKWs4RVZNvzlWwgh/U8tVMSz2SJs3/0YqrNvSX2JwJe0gYAALgB/4WwBI0AeNo9wX9EXHEAAPD37u79uPfevXt3vbvv7+/73jU5yclkJjPP/piZnCQnM0mSyWQyyUnmTNIfmXMmmWR/nJlkJsnMmSSZmZxkZk6SZDI5mTPJ9tc+H0n6D0tZaUh6I53KvpyTR+SCvCivyTvyvnwiXwTcQCaQD8wHKoGvQSnoBvPBheBqcC94HGyGrJAfWgy9Cx0pupJRfCWvPFMWlYpSVb4rP1VV5aqvDqkldVM9U680rGW1Hm1Um9bKWkVb17a1A+1Ya+htek6f0Jf0bf0k3B0eCE+EF8PvwtXwmWEY7UavUTDKxo5xaqomNm+aveaEOW9umNvmueVY2Oq1pqyXVt1qRvxILvIwUoiUI8uRaqRuS3aXPWyP2yW7Zjfsq6iI5qLD0fHobPRttO7ojuv4zoyz6dScy5iIdcT6Y3Oxcrw9PhJfiddbOlsKLbMtR65w+9xBt+TW3BO3kTAS2cRYopRYTuwm1eTt5KPkQnIpuZVsghBwAAUZ0AV80AMGwAh4AqbBHCiDFbAKNsE22AM/wCm4gBK0IITXYCe8Be/BfjgEH8Mp+By+gK/gG7gOP8Ev8Bs8hufwEunIRQJlUTe6i/rQIBpDk6iIFv6toI9oF+2jQ3SGmjiEHUxxBnfhPF7DH/AOruE6/ol/kwCxCSZt5Dq5Te6TPBkm46RAZkmJLJO3ZINska/kOzkhDXJFDZqkaZql3fQu7aODdIxO0iJdp/v0jDZZiDmMsgzrYj7rYZOsyBbYEquw96zKPrMDdsR+sT9c5XHOeTu/we/wHH/AR/kEn+Hz/CV/zdf4B77DDz3s3fHGvKJX9ipe1Tv0rkRaZMUtcV+MiBkxJ8piRayKDbElauJINFIdqaepldRa6nOqnjbSfvphupheT++2Gq3+X95byaAAAAB42r18B3iT19Xwe65syXjLsixs4yXZkrdsa2G8LctDHvK2ARsMHhizhxlhhLASICHNIglJyWgTQggNIWT/bcPfpA0JSUtDEvqR0WaRQNrsphl+9Z977ytZlk2/7/mfPh+WZfvq3LPuWfe89yIQodX9nXCarBFkQoggqEwyXYzebC2IiZb3t00rl6ekmHQ6skYseSbFmIIvAf8RYQa8CjHkCM5R4ByFzmDC7+UhxSE/4Dc58jb+Y3AWIYk4SYsQLyQJQppOobPpbCb2bVKwb4WOfSMCmw42Hwx3hvcHDqgG5QMRzoiDEXURi+RDqkXyReHOXXeq7nx43z7rCcte/Gc5Yd136gTlRSY43A8QEzmNFPRCjiBAIkTLFWqdJRcspmiNxZALZqvNYlIngkanN6g1ZiOoS4HIo2OSwAL3ORpXD5XO39i4L7mtY7C/tGteSJNywbae1LKK72al5ySCU9O4a1De0hq0qGtV2OXQuNrdsxX1DYrOqubQt551JoS+HVgKJ6x1GeEhf6D8BAol7m/JXWQbaiZCUAkJQpogRKE2tajVGL0WyRZY00ygA6piHRvlg+YvG+qX1jnXpc5KxRfEtoqzW+Bha3291VpX18YGybaG6+obdjcuyM6el5l5cmwfRNfvqW+4tsFC/57H9THb/a1skFwtpApZgg31IVdoEqHAajOFA5IzAidqM+gtfJkVGqstgHJgM9jMjMEksNqs5I2c6qzopHyDzBlgLzdUGuIGti3eP78nvHHxsUVN3YeqssU5dW2PtDx7l63fFpcYPxwph3l7OtKUkWk5ta5kXczsxbfWR4TZm8va29d36ve1bhmy9jkqf/FSap6tvCAuNs+spPyCEA+nhWXkAeScWdIyakEPMPsBoc59I9SS88I01GGkRsGWUnPXscKFAwMLC4kgDj2aPvv8xbfmZCDsDISN57DWSIONmYHhtAQ7BAcfzZjz1sXzs9Mp3pmwE4bII0I40jTYNGi+No1CozAoDMdGp48ElwaPTF87J7u5OYcEpFut27ZZremzDcPDBjo3Ct/G4DL1FlCb1Do0NZ3FZAHja6+5XnsNLp+zn8MXly3RfYtwQlhAYT1epTBYba2JSYX67Jyi0jBZXHZiTlVNTEIiNV1BDwBWcDBdpKhT9BApfgGOKgnXd8KtwjD1OA+uMvROrXaaxzNBKHQ/BTvJBTof0JPB3PyTi1z46W3qiya0y2TJLhFFJFpkpDVAski4e+fOD3ftgpj2+9rxRbY9JL740INQ9uArO3Z8u2MHxZ2Psz4m64Ug5A2tSalTyhX59oLypgILqZqWObaHxCbLEK4ciQHSmSEINpTBYrZZy8Bqoaal0JUys4+AcFDfCMvEqvb4lM19levr5V2BV/12g8txdZ6xrq53hVkZVqDvyispKGjtHr5zTrwp2pRBeTCjDErETYWNViSCmvqVxUTt26zPQoenPz104Pvlxc6tr93USuZe3+hsq82vba9aWR/WGrL2qS1wbsCgbCppG1yyoLzK3l9WVthXarC0tSzg8S0O32LJViFYCENKSr7KKRaQmZTwyLJljeJzUHf5U7JVnFd1xx0lcETsgmzKX4X7Wxgjo8J0jHbmLKBrqLCaCmI4m9GaGGQQjt51JB56xc+VZuOidZtf2Oxqj0sqbzqzHgpqn5g29+mN/V2tsYoWga/ZN0SG8qoxjgiAkqmjNaWeyBFJMWsCePDQwxHlyQWB8sFDq9f1rdx7/cb2kSDxu3rn6vp6eHPhrdssup62FceWnIS0x+c13Fez3F65tpLbKPIKLyDPcmrPGJdQzBfEv45ArnicjNaNnSMZDSyuoGykiPGSJGSiDfD4oY5m8YUvhNmqCQfOjhFoHCkFuhyvb9n86k6HXelwXvvR/pbryxr67pqbl/lxdkZdcVPr9nYoLVxY37Ow0dwaLI+rKWnoGWosbVIpKvqKzc6ciPPxhsgZpGh+USHqoxJ5iGK2lYrcovRIX0F1wWzAhlZmCAfGiCeoQpypJ6X2OqNt0YY2UjWcPDcweMHPV6+7Y7WzflU92Zad0X3Dtw7Nyo7CKlXhSxkpLc0rOrtG6lA5NcuR3kxBI/wKnuU+Y5W8jkg/ZzPvM7F3DfdBKPD4IkFfvEV4FeeGYBaY4P2e+cu8UUDJcPjEAmga9+l0IR3uIMVsfcJAkWZJgzvEv0KyWXwBionwxzMlFx2fID2XMAp3wkaek9PQ8eg33Ck+CU7xyWeqqp53ONh6GxHfIY5PFagONOTAQigWXzBBovg+Kf7EcbHkzB8p/4loyy+irmOpt6m03KfocoeDQp4AOou5lJj1hBu3+V+jynbF0t+tMs+K1QarmjKX68tWmbVaczKZ2eOc0+cwO5LDY8JjjYacMntxToNJzNUak5ONSMfurpdtRTrBQgmyZ9ZRI8eVs2mi0VnokupxSCGPjDGptTSZl5KCRKJmHmAEltNwudET1KSsqGierdWsqTREG1W59+9r3W0cOPfMG7vLqirX/eLJ/QMzr+nMMgfKoorTnfN3zi12QEr7AqdlljEnxxQfVzJ//cGZxgHxzWfK11hvO3HHilJr71b7VQdStZH6vIX1/dfW1o3HhjT0FwVyjPWSSmegdY1J9lXf663WH6xth84Ok9Gxfffe+y5Yqd8MInwGwkegLSXRGVyL1GcU8iyw8dClVpr4L4OX+5cUFRfVrMos+exSbWlV5V0HZznsxQfJ6Lwaa3N4cKt5bUaEY1Zf4eugKRyYyX2YxnYr6jCGewUmSh21f0SJUYcFeigb3KTpiO4odA33zqnv6rj28k0HyLbBFmWRY+fl/a6K/rUnIfcIlW8A3zqZfJEMWyQyqVRRVJQ9SNh/9Oj+Z1wjizdvGR4ho0fFvx1Fcf+0b8mSPZwXnA8XcX4Iz2GerwHYIZ4BrfgumMUtZLTqdfub3B5RP/ABwk8bh1fqBmGreBbixI9dCHq2SvxwXM4irG1i0cLlngio0EuyloDBgnkJLmV+ddeRrc4V6Q0Vv9o43F3bfehy+dL1xyHzeHFlXMv+D/b2zSNys3ha8NAnMyV+lSlKmtiQAeVJsLhc4itIX7wMaiy1ZogfIhSDF07ibzRHI/Cgy0WXm+MKQp+p4rhS5VqDBe3YghihqvdnrupN2S7XnMzWvOJC+K1Y4aXd4KENpmmgk2HpqnwCYpeJf4fUoa9Lm5H+O6ATPxIfBF051ZNHZ2fw90CeY5WmkzBdvNPlcIx/Ti7j76GCEE+oRDKdDN/fPPfnFa7zlgtUqE54eGwfCRSd8Ouxb9g0nNeP82qltQCqCsBZp2Cmq1v8HeVEAd/jJEEU2AReU7Qz342SbEU3Mfrar7r9wKZNt932+vGhoeOLyLbD4qkHDh+653DNzn9t2/YvhoPSlDGatCDEaILOoEPakl/AgWXLhje7Xqmw2ys2k9HFJxZ9jYz838o1jh8EiYfZjAeWIwORASPkArMMlptiNAU2IrFD2tOzO0qMG2+5bdNVt4/MTUpIz7I+wzi7VTXbTh6E4sOH79l5nybbgNl/vYdFpEH1mcX0GY1/yxUqnUyHmkEaColNEt/WcnLoF8tdF0ZW/a2mrsZ+PazpCxd/BBDdZHToLccq+/dcxw7U2XTkN4lmdB2vt2mxqtUbTJ7cSQtdtGw4qVxXVpVp3GF3bf7TLtLYtac5P29FU/PKl5cEwds9tsb0iBxN8039i+eXVpa05UVmxNXu651dz+nQfPE582PqV5RdnRw+fdX1KnrU2B9JPoXpQl4sLDah/UVL1spSufLB7p91u7ZfuAaVvby7qakbbhaXr9uwYR3czGtgksJrBrQvNK7Bk0+0vdf6LnrC50SJJiLZE9bXspVeO4ynNWkI2vjQnXdZDh7verdtz/62P+Ccb+Fl0UpC0MluEZd55hqRRgv3jRSdQaFTyRgC0rLwySN97743/+SD8//y448wE0pEN2r5BToHIzKJxzlBnC9q+MNHjvW+3/weivEepIg3iCIQWMP2Fgir4bZugzRLihoC1Sl1sES8DV7D7yViQQ18IKutERNktcyn3AchC2trqk8TtVC1bvD369f/nlyoHquv5jznYP29gdffNDPkuH5q5uW3AO6v3AeFp/l8jY7GKYvpaTp/qJo8UY1z1cK3cII4qU5tLK0o1MdLjnevH/0WOsSj//wnxW9z7yT3uF+i+DXo9zYyPHbHzCqpjiMPQKqsh9HGrUzhZc23sp5dBauo/VZjXLoAlzBuammOpYWkDuty6iNKnYHtCG3WAo2aVZi0Rr3Buqisa11q5uyBqqDsNU09ZtPB6pqRyqFZbWCtmJmRvTwuaE6PeKZ5bue21NS4gmh9xpw26idoT7QvEIa5DncJUqGKi6c0ReGmnJv3ybynr9o8O68xJsrmamogrpWtLXB7256/7csztpMj4o91FU2Vrv5fLkSZCpDvV5FvNY0M3rTGsxrbxsLsgYjmsFm6clfjmsKWJZ1zr94Kl7oqFJnGvgcGLPmN8/d+tBv5KkY8n3n4YoHNwCoH9DJesNowucGhpvJgTUPO3E0bn7nZ1bzSRZrgdoga62rOyb3+b9dVL/xlf31Zk70J8VG+3kK+IlmlXyDtranPKlKiY1SsYkkxQ3B/eEvI4qa+DRtP90eIz9Ru0qSU1MgFt6Wr1rXnw+vuXumcDyOhbaUD0v4K5pLHaIRhcSEBTNxrcXOJmDXQmKLSpff3N7lcTUMGMhSmzaq1it3wkBWjTRjf+89wB2NtUiQYhAJhFtoRjcU2yhfuGkwKrSKG1U0ouzq6iFdzPFwzndI4Jo+SNoQbi40664o7LIqaWYruAN2KtsLs6OTuZ+1Nd17abYpvO7IqRXvK9EXpstKypaURCcVJxqC8u/tSLeVNzqzixn5NQEKspdDUsLqrMss6s8FWl69JIbC+omLYXuXJTwpcDyW1Em6FSmqVWFZiLstb0TG/qeIqp8sFuwdWLhAvQqyjetHc9wmrT2ib4/fkhKdfpdRFSfX0iMsVER+fl5AA74kpxBWfE48vFr/dD7uDhTdwjoJakgdeVsCiHd0/GGwx17Gpt3e75szQltYGlHkQjAnLiW7snT3JwWmONA/v0cgKUrcpWKaymTAhfFPucl1c/vbFBWPm02jFa089Lr7hycVYLxzxrReOjHV5ayVZK9pRoqQHjb8y2G6WEnnMuLq0XZVzVec81Iy9qWKDk7iqYPtwiXWNR0MD3Z/QHwu7LsO7HDeRI25/HXvQUR17sHhQ8Lncvr/AuSwnR3kNxdMtOPbSpk0vbYLltfuc1fsa4NL2jRu2b9+wUbdgwdEFC1i+dKtJDM4PofrmcUBroAkziu/PMRI8anxuy9ans10VL3e0rHWSBritY+/7exziBXJa7O07vLCudG5ZLc/vavgAcYUyX2N9NFOBhjYgCCv7bNx5b8t4buuW7qFcpbXp+ZbOwlZdKDQ0dO15f++cpjEbuXHh4b46TfLcygZvjboYLrLdvZYpRE2RKvSQvirA5UqdmxAXkAh3nfgU3usZmNYYTOfQGHIW+cC8HUWTs84/efMuhBH0lobBRxaQxmmD+Zb07L6SipHfjMgaiGO4Kj2ndwv8srrWVpFt0oUlq4oWtXXYc3KyS5JDk9J6kYbW/THMJ/1Ua2lyg96AeZi6v4n2mZQYmG0wv7PGpA5pbGw6cKAqLTc8XRNpitWBvnjXrmLxQl0Uy+nfwffwHl25NFaOUSOnWylWGz+cv7yl37WyooW4XPOH58yDPPHNjQNNX4opnt7WR2gB3ry+5Gc3zf5N12/gXXEU9ola/EiQ4Mjz+IdfXh9Yu7py1WjT3Y3Llzbcg3N2wJB4AK7BeS7xMc9c3D/Bx8ifJ6/bDCZcTQV81Ldne98TT/Tt2dH31BNPfP7FyZNfMPhAdzC8gpNRHg1b7jLglQDu9A2B+db0BLUy/IXum1Y1P66pX1O6T5+eUJTPiG8Z+11dk47isODbYcTBcn0KzfW0MwWxaPWraXkv7i+HeeXl4v3lnMd69zroIJ+x/VpMAmYI3HuWgKfFhL9h7lRTD41WHDSXON9QqpT4Wp1e5CwxgzG2u7elw3GpJyu1QZc996H8KEdHa09nPKshdmMs+IdvLPjHT3d49g7rIEqiqafEdJYCSroIy2FOSo4jjPjvfGhmzKI0TfGdPa0djstzs3UNqVk9D+UhzZbe7lgm+3vwGixicUCrMNBQgFrUsMSsP5Q2PTvFqd0dlx6bpWvS9IUbIK5Is8JWGD+SKsfqze0WGpG7F8jmyAghAGLImucpr5ijWB8uzTdX4X7WJPWZU7iaeOqicQ1+FtmZWfjkk2lP5efI2+Xt88TnZuh1c+f2zq2ZEwKXmsprl80crorLyG5sdGTnLp25rH9Zg5PnNE9NR39T8T0isxh1iqfEc9KyUTk60L5bbDTyck9w1/+1trYesidWfTSeTJeFQKZsBe/peHJBgfTTkpCQm5S0KTExJylJFpKQmeB9MV4S3T+RP5FH0I6mC7k4EilP5t0HFe1SKORqOZoobZ5PWayQP70svv/yyzfecN+jW7Z1dUFn547tHR2fdIXXhJiSCh1VgwU18+qbV66AD8QPEOxnfxCPbnm0q2vr5rk9MGcutDXMkqdldtzUbcyqar/q9DraoxHS4AQcw30gy4UKjc6Qxt6Pd+zd23EzlPEfx17g/5DjAIwxP5Fzkgxp9InJFaXQyykqnXriRufcVELcUGjbXLOywXp7XePBPFN+7oKpZThUOe3x48fh0epbjE25R7ndq2XJsFA24ul5q6FRfFw24mSfabCm1fKaFhQGG2i/0VyWxawq2IWf/cXdBMsRCmNRYLSObrZNBRazTqvDYJIIsHylJjw6otgaFRiXHWnQDztJOklJcmZAir/eQKdRmGxp7B2SmcbEU36KQz/IdX8JbzA/0MLXZNXz1B5YLwj5o72gcN9uUAhgCe7TEerHatzbFYJaVpb/u/kyFYrrM383Cj4+n1ANjM8fZvMjJ8y30YcZvhhOFlyzveCkF8fThqVLDXeP43AyHIkTcBgwXJRCAX98pMFwm0t8EFYlxyaH5pq1ufFxM4J1IfkZ2mK1F/0/TCqTRakJjY3X5JlDk4LQ7jgdO6MTRf/yocT3u+Nu6EOm08cjvehf8fVMXBuOeyBSD1UbS6PktDvs7dW9w/a3Kv780bcjhblVBnOesradh8vjram81ffeK7Wn3oU28ZjUd6pj/bUsP1tT2DCGSl2oCT03hTwC6wK4fqUmDI3QppTHDlXUHlg3sQdnLx0O0+uXccuE6qCWOZB7xKclN8sSqIMUqScHF9FOQthO3UcGutOb0FmbxwyNsS/t/qjt8vlrIg3CiHCvoEENpTP9LMbxz9B+Qlh28MELzHwW+2KGdZIFMeTkDDcgmYTbzvrc8ROx+EfXCZx2TVhYjvS9CRGX0L0yqJj/K3jGlKG8mDVLJHdiIqJ81ItjUD69MPINlS6br7/7LzhejvLJWEcL56uYXIjhgtcdPJJQXwhgeOxsb6HiM4ifDDi3ys8k/diWelq16FPTaE9KRTuAtAkHtskO1d8MJd0u8aUW7k0pRj9v4s022ni7wd+lkEvWf0P9UI+KmboDhwrz68KJ71Dt+bXi4DAzFtQlx8lt5TFmKwXCOK1hRmv6lLRkTLl+1EK5ov3Jabzxh+N1Mrx6Wo/T/j96UaReLj1bUE1WG9iRwKZNB27/8/FFi44PbZxKe9sO33Po8ANQ5iHZODkmcdp2KSJpp5RK8DMAf22+4WsN/mJm+pUQrP41Yv37I7NZ6aGzzWDTwAnzCe8LfvT5Q5C5v3d/Qa7H+CPDLEHXWQOGKTglndax+y3g9Ou52sYOW8kcv84r4b0/tB0WG/27fzbky9MB3Meczb8LeNFjLxwPt5eTzF5mstjCx4cRv3oy/jQmtocC3C95oz+RLo9rouQcn937HMUPo9VvmTy4d0xwVn8CI37rg/KwelOSZxuTp5it2yb3jySCPMXiXQk9IUF3IhYz3aUZ9Ao5/VJHJxCVTmYxW2yWMg5is2pi+FcCxDAo9ocims+gXwaLBMmeXzJ0Bq0ODIYITWgYAAQERMbEpaRHRQfJoAXrWJBNCw2PVuvzLcm5MaEBMoAgZWR8dpQhIpzIFdOCVZExqUZdri08SxkXJg8IMExPig8MlUMgzCsIlIeqZiQlBEFokEoRHxJGIDRienhYhMp5m/gWZNxWFqoKlgfGqeIjoqcpASJj0tWaiKDQwEBzUmKcSqnNzDROV8crVdHKULVCTooDZSFhyukhSnVwfZomOBgIYWvF9srkAsaJFLZHmLLj6NtwpHEddkxoOjb2LvL0HF9FC5zUd6yV2o6kk1qiL00tiyP/LU0brbGuRLSwlczAmutKVJvL4Bwrwjx0LzJZDf8TujwHXVlaJ3OGK8oLvx/PV5z2aSaz9X8ks2yKWHplFfxqihrv36jk+UkpCmMs5/EU008G63L+t1z659wr68o3+F5ZY+cneDn6OOuHy5S0Xhy9jB7OWuioTxyX5cMlIQhjWDlWjB6GLD4so/uip/JOr0lq/RrU3i46AphtaZ4O8A2cTQ/7BRHBsoBi3gyu4M3hVpunw45bXwCl1CL+A+P8MUminLCogIAq2i/uqnXl66W2e/C0W1jzmPbJ61ifPGOq+pQ9SpqwHZWq0/neLVJsg6186xHfVrrVWBtu8KlNix0f7fbpq+dlBKbS0pTnbzhP/sp64TP+TTecuXiIX0f8qpjkUiruB+jhk7risNCTY1i/nbxD67u11+B61UrrZaXrSD5jtBP/DW2+G4LwK/XjmcdNov9nydECJBlPMTrJtHa+IiX/ncwVJb7kY7mTKPvXwaHoNdPZcyWfOniE18Gs232B18G0Xo7ievqC6ukNqQ5+F8cdGKP86uARTx3McNSPxxWEgniU99/UwSMT62CGode/DuZ9/tO4u0hjnVaDTmmysHMkmLfN+ik2mNC22jitykWcGyqa5j83Vfi5NNwjai93Lax20J71gpW3T10Xw5eoL9q/Vk/Vwab6+9WELvbXVJUTO9mkwtf+vkC90ppgp5tqtlUYp3OR0dFMRYfreSKlVK7yibTgMc9+iuM8zXCi1gTpPAzi5H10/VTl8DpGQbzFua+2YV+1c4py2J/exaliNad9itFm534mS+RvBxNl+8HXJPwo/s6/FpYJYe5PSRR8TX+j60Tr2skU4f08MdN478RnDl/ni4Y8OOv35IHXnd/B9zLgKz+5A87CkG8X/H1c+ImdcBmM17aIS1r369m6d/vQCOOrPpmGlOF9qVjZok+kQ1Z51pzTOeXR+mSMkzKiL+5PfZTuR6F3cn3L+uk8RgxQiXoE3/G9KOug0OGO5594eytyhF88dLent+LJoWQlwi8WFrrlPIt64e2YW+2bF02CP0bHN5z15FwK764jzWQ00gAO4TX3T5FsBoNvJKFwiY3vpU1KCT876yTV58dYfa73+uirXK7NVK5qCT+HvxrpVqyVoH3gP6XjhZPhcxC/UviYvOiH/3Y2/ggx8hkT8FeuVU2B3wCVQqF7ixeena9CeDp+s0BnGNg41knkv8gRHC8nWiZvjU/vhul/5G6pczOeE7n+25n+a33g7YjHjvuXRXyGF57pf+SsJ4d64bm8Z5i8vvBc3qeYvBJ+XC+5tF472Xp54CvoM3HE7/jwm0n4mX7mqCbxz/VTxfRT69VnEdNPhbCfrW8mG2fPtmWz6Hot/TOOOn3Wq0iS9yST1weeiFTerdpJ8ExeACavL/wnTN7nyTY+g8KLl+mZM7ouwl/GIr3w7NyYxOcOxmeWd1whe4jyOVKOo/Wcrvtz1EOWzIbj1ef/7ulRecbJfYin2n3e3cWzNo5/zM5ws3U/e7cPPBvn6+4+y9adw9MDIjrudxcX+cCzcb7uF896agLkM9tdJ7zJ19Hd7v6Jz8DxfBy/QE6w8dlsvIGN04z3kmQnZqa37PHn2/CezzMtWgtwGvQ83J+477VQDeVIPD2Msaad+94b6HtQLPE0KP6Tnodjur40RmNQrnc8mvuG8Bobb/LoGs7wvt88it8o4aH1S7Tsbjr+FV0D1zh+em6O4XmY4TGy8Urxn6gLjj+Rjbv4PRfEc4k9e6IYNYEGDTttB4Vp4of6J9mZO3i78I+FL7GDd4SdS6/03IuhrTeqEUhI+yltANXyauHThXAre/aPNGmP0MnjGKQz+8n3xocMnnNAwXJOC4dHHdRKvH/CeJTgcVzO4mS58Ac23uLFXyvFmb0szozjl0t+N8L8rsWn7ydn8eQ699287+etfXic6WT21uoDz/3uEPM7X3hmb0vPSpXSf+asoIziljngH0I4ylLIT8TTiytWm9lituSC796M9lm82zO9Qa5gNYV3Y7Y5ldYR+lRCvnypJDR4WkgJLc+fBVmKrlKq2IuDg0LCSl7aRK6OSSmtxpId1uVhmZGf2xwoDwhovL8iNCIiDDdlQYryrLzu2mZHSGhkeAVWI7NCW+mRHikWZEm56pdsjS2etYHlPFc10BXu8LH/LGmN/4utpcVjn/S8go99dvjgZ7F1gYpD87VB/AelNY5na8zh2dlDiZ+jjB+rJ/fgHp3xM0T56ZTwcHjmv/MkaB945r/FE+Hr6NlGxLMk9scJ8HX07AQd//uPU+KvnKeaAj/lv5jx38nG5e52eqaR4nmPWqJNgtci/vmkn44fpvi7pHF2BpLjN6omwH8MRxGe6vNr97ORbIa3l2mjsVi4yf133sv01oEsRgtrWIzu9oHnPrOX+YwvPPeZpcxnfOG5z9zLfMYX/hgb3+4+6wd/GMerhJ8L10yE5/2Lqy9LVSkfL6XnOWkODvtS6sTy8XJ6JoSOf/J15Dg8O58p5bBvmD3MYuPsfAfTf4VwiMWgOT69UWYPNZ7O6HjtyOwh07em5PDJuC6Dqx/zgWdnLyU7fIjRLWHj7JwGt8OVFE/vBHiee95iuccXntcot7EapdcHnq37oIpD+8Bzu9Ixu+oV/nfO6P9Hz9WD75O6i+IWMIvvglY8Azs8B+u9dTjTQZdqUh3OddDGdMDqaulZGYM/pfKpH9g4h3efYvBv+MR/Br9BJT0lGo//HH81g2/1sWUGv0k1wTap7XP4XgbP91jp7q/hVfiEn7Hk90+km1S2FLNeRh8R2XTR3/q2V6BGaq+44aHxlop4gB+xlHTyDvdXyGb+utajE1k+91cIYv56s18tWincyHKofy1a2f2aT23JzvNL8LsYfK5HhySa1YSVp4p59SLhL6U5kfpl8JcTdFhKz9/R8fNfenKoB943R4N+HN43R4PBpwagfmYXnverMeSsxrALD/vUGFw/vCZpYPC++uE1STqDZ/rhz6UkP36Qwe9i8GxfTz6mfrxmL47e74n3WEvT/EDj7u9ZLS3lH/Eyyw90/CAbl+I95r3PpXx4Pct7Nh6/EX6+FL/bGXyXX01eiTW5aoqavHJJ8XhNLvkIjyunWVxJ9fERHldeZHGlStr7tFMfpHkmWD5hL1PH9z7Cks9/9Nn78PjHaviuuyfFS75es5i99bAz4vSc6kvwV3ouUTPhdGqK91zqYxOOo2LsipRil0JQ0Z2kSopRKilm0YNZMr94Ri+snuQh6y4Wvq65xuUT0jo6oAfDlhiNEayxsork+US1PZXCf/yc93/6fDYIqXBBeJqf0Y3yuXnX7b1xRxw+F2/52fmrZcP0Pg0/+QBX8yeS3rMBFOYIwixlMAii0EgwMsc4TATpgGLyNu3XqkwsQplQMbkQYQ9qSDfIqkJuSC02k7crtcnXqsppTUyKIEmmx90FvVcincbGxWJ33thjcEhyLHQ48vOiDPEz9GkJM8j79M/8qptsen18fDrSPO9uhO1oaRGCEKilt21tGnpNNAZ/gHVeblhkli0koUCZ+HhbelZYsEJnjA5J0BrjpfNVf4Q2mZP1eCd3FVdO0UaUkUl9Q7Rn6a5gZI2ghQ8EDDXSOUobAPxi/D6zDZaKt3ruM+Nn5B6fz+hdBs9nqfAX7/qxE78oDFrv/UkzDcacmaVhyOW/knIduHzJ2SSO04rAOfdLc7wrngupyYVpxmw6J4nsS8yurtEkSnOQ7wj3AYxNQ5EKwIgw9ms2JtGOrAGM6gHby1Eazzj0sj2iU3iA9meA9weQLlSx8Xoa53C83oMbqzaK2+WLm+GogaYJuBMxB/4gDLOexBDioHHncdYDUvK730IaBLLzatIpv+Pj59P8P2fn2Nb4fj5+l5P9bwQqk1xhtdGrubpJtzqzIEY6dHF4PiFBQTZ92cwJNztJQzi71glf19QGBibmNJgmXu8s4tc6kadQjBFlSDPP506iAvdeuDdD8zQpdGyDxi8o4gZNZzOh8VvwB+7goGVwtaYjuqHQbk4Og4gYtwCfxZwJUWc31XZ1XPt2dWZkc0weOGIsEdZ66RZjVWZppSIoJroyR+ug1xm7rY2V0TFBisr5JV1Mhxhh4SeMk/yMElLHyEifvwfq0iyslrCYclH+Hrj3KUdE/zzFynQbRK0UvyrpapddvhjS1lBCRvNT7XlrsiMCf/hXXkNhXi7dggouIHAnt2Pw3Lh12O2ePS/8jRgwNoexXjq7dB9oTlZHJx9+cXT0xbXQK34DocRws/jVzTdB5HXnzr0+ftc+YeJde0deeZPJDJ+GZIx9AL9JJvyuPXyL+OM8d+2tZdKd6/Gr9nL1jTAoNjgbFllM5Wvr5F2Ba3+91tmwYkFdXXtzmzI2NK/Jmmts6liwsy4qPqaR6WqGez/8HfGmsqc2OqtP/vBeuKdnFTxX7iFgubot5re9awtNJbXXnNnZTNp2dM9OzCzJqm2rgg967+t1mkpV0fPLWkeGFzoqaqzdKSFl5oVF7Dyu+3asCbRT3rU/umxZE71r/+XnRCt22e+5pwQeFVvAxO/a74cfSAo9D6PyuWMfI6U/VMdzuXmLN+z+zWhj9dbuFtf9M2C2+AWkB4/8n60DswuL26+uhbwa4X/vnr37ELyAOp1wz/7cApglHiYG+9izxF7N8rkN/Sb//+ue/en/4D37/Vi/GbxnojRSt+aKt+wTLb3JldvX965rIxWLk3oDg+b9fP26uzbU1I46icGUPVs898SKzsKq6MJXcnSNHSs7u5ZXO0YdzpX/DzC2EEUAeNqVVE1vGzcQHVmSWxuxkBzaQ1CgA51kVFp9oDnEhyJIAAGJlTiwDCPHMhK1u8GKuyVXNpRzr70WBXroT+ixp9576m/pT+jjLC1LboKgIkS+Hc68GQ5nSERf1lpUI/nVvtl7E3CNPq//HPAefVb/PeA6dRsPAm7Q/cb3ATfpqPFTwPuQ/xnwAfA/Ad+jVvPrgI9o0vwr4BY93D8Fc61xAGeX4sXjGt2v/xjwHrXqvwVcpzf1PwJuEDe+C7hJDxs/BLwP+a8BHwD/HfA9+qpZC/iIfmlGAbfo2/0v6JQUWVpSShmGIgZymJ9RTgWtsZdSTAmVkHVoRsdYRzSgIeYu8EvYGFqRhjXTFBoJ2BS+HGxSyGOxjMGkweeg4Xc12L3EYUSQ5bDy3J5tjvUcqACXCsxPgSrGOSSe0e5ovN3Z32Y8/OgZPbqSvRSzt83hnTEvMFdWXr8rskI0PMt7ePAxLiC1WMdyEiNnjzb+/l82h+LlhUTgY0kkE0yvYWHw5T0ZsSp2JBF015BpObcTfkNPMPtb8Ce+zYX3cA2ZZ/cZ9voaLFfhPGPx7mN7Bdul7DO1t87T3rqh9s45L8TC+2vDI50qu0yzTHHq+FlerG0aJyV3Zsc8GgxHXX6pzEpnPJ0lS5W5MtUxd2Kr126mMl1Y7Vw0y5fHrMycz1WRKCg/VVCca+7YSvC2+q4UD7c9Kr5SNlVlmhvOF4ytTHU5L8p0mb7Xc17klsdWm1kSHcrmB8McdvlFblSZKMOvU5Pk1nCnqEBUrgs91y6NzZN4qdJMoujydVomfK6dtlfwM85Nya/UUjtui5+2HKjCfKEQcNsn6059brJHckkx2isTFTrX8SpTADdXNZYyiKUlRkj8AOvJpni3S36XqdIaYfToMf5VET4CMUIe5zbWPIoGfMKbtAbXEI1Gvcc95OcRfdIN3TUnupSSc5tmG0rUftClts5f2TAaDAb/Je99jLy3If9U/9DdCyV6JyZ3m6pqGXqXm5sLx/0SqjwJHX3bK1N5L0p0lpJ34KbnM6wzeRdc6K+VdI6W9PsItVg/pwnWM+lhs8M82WHw3fuh5Pk/XSSoYCm3ab4or5XVvqSzdKaNQyGuzFxbLhPN0+cTPiu0qZQnlUKXb1M/BJt/oEoEdEJ9DP9k+4fLP4D+sXbhWakqr4/QxwiVkrIsTvp9N7NpUbrIoSdQR/2z8YT+BfdzgsR42m2SV3AbVRSG/9+JpUSS03vvPY4s2bGdLltrx4ljJ7aV4tT1ai1tLGmd1a5bekKAJCQklDxTnoChtxmYgRcYehs6DAydB5iBR3qwdW+kZYZ92O+c3XP+c849F0XIPdfPIoT/eagNvVCEYRiOYnjgxQiMhA9+BFCCURiNMRiLcRiPCZiISZiMKZiKaZiOGZiJWZiNOZiLeZiPBViIRViMJViKZViOFViJUqxCEGWDtcMoRwVWoxJVqMYarMU6rMcGbMQmRFCDWkShoA712IwGbMFWNGIbmtCM7diBFrSiDTHsxC7sxh60Yy/2YT8O4CAOQcX9OIdruIyLeAAX8Bku4Us8iPvwMF7DK3gEHdBwBXG8AR2v4nW8gzfxFt5GJ97Hu3gPjyKBX3EVH+EDfIgkfsJ5HIaBLqSRQgb3wMQRdMNCFg5s9KAXfRhAP47iOI7hXpzECZzCafyM51jEYRzOYnroxd/4hyM4kj76cZ1ggCUcxdEcw7Ecx/GcwImcxMmcwqn4Db9zGqdzBmdyFmdzDudyHudzARdyEf7Ax1zMJVzKZVzOFVzJUq7CN/iWQZYxxDDLWcHVrGQVq/EYHucaruU6rucGbuQmRljDWvyJv/AdvmeUCutYz81s4BZuZSO3sYnN3M4dbGEr2xjD89zJXdzNPfgBP7Kde7mP+3mAB3mIKjuoMU6dnUwwSYOH2cUU08zQZDeP0GKWNh32sJd97OcAj/IYj/MET/IUT/MMz/ImnuPN+ARf43N8ga/wKW/BE3gSz+BZvMRb8RSexss8j4fwAl7kBV7kbfiFl3iZt/MKr/IO3sm7eDeveSNpVbPMjFcV9EQ6LL1H96g5eCNmwszoXV5V0F+rGZbmpDtTep9fK9i+2rhpq5qmZ2yfljc9UU0dkozn4FVkJV1WUkQlPQefUlDQ86ZXkfV1QY8iFPUc/PWubhKubuoLWom8GajXzHRaFY5/sys1WbA9DbaRiuseIwdvg2zZkC03iJYNcTgNsjlDHs4Wl+bhgh3Y6ioc6HI5nkZVc2zdk8oh0OiOS/0nTozdJMIzIrzJHZ5xhzeJ8Iw492Y5hCmHaBZDmAItQtMSmi1uTcut2SI0LYFWkZXNwd/qGjzrGrzNrWa71dqEjC0QE4fuiEOPyX4d2W9MNOrkUByzjEyi2Bl6e2NyAY5cwC5XH70ue4/L7nctu11MMZCDr71wawYKN9DJGMGyqjLJiKQiWBuVvOHXCUaDkjIvGpIMS5ZLynxF/lfCnnpxJAmxO/G1SrJaUnah1EjWSkq1OhlfV+2NKLnZvKouNtWcTanZpLDNgh1odW8q63JySqGyiGSNpCIp5g2FVktWSlZJio5D4ZBkWFLGlUu/4gYrfWq3mbUtszupj1Q7DaOisjxYWXLEMW19aP1WVo8PhYaConQoGI4OVxzL9FtOt65n+9MdZiowoFtmafegiJmK+wdvRt62e/PfS+ykpef/BDpNxyo4Rk8hJ2v05XOygy1k8p5uJJJ2PiljFAr9C2XzY3UAAAAB//8AAwABAAAADAAAABYAAAACAAEAAQFiAAEABAAAAAIAAAAAeNo1yjEOQEAQheF/NgpBHEBBXMAJRBSi0tlaqDQbhez916yQyWRe3jcIkNHRY6Z5sZTu8BcVifaEQPQ/g9zeHaQxvZt8N8VQU+jktDSMDOxsOE6xsupHlEKlVRlVdk6crGIfKhAPoQB42n2ST0hUURjFz7tvqilKCqpF7WL6R0gxiIM1uHqYWobaZGkaBLVKWkS0kJatWruuZUkgRIiExYOMJhpIY4IZUnhSgw0h+AgXQ1C337tatIrLfffe893vnPPd98mTtE0n1C4TdJwtqGn06u2b2qcUuKxVEv937924fuum0snOzZSMW9Py/Pvu5kEVdEd39Uo1fVdDv7yUN+SNe++8edNues0VM2rGzLh5YB6bSfPCvDHz5rNZMT/8tH/AP+Jn/U5/yL/mj/n3YM3ZqtpsTSeZebusLrumQftNQ7auYTAP9Kt2KWOL3GnolI1BGgqIdxA/zdrJ2m3L6mctMC+BDdolOBZ1mXPCMwKWVrN2ojiHYhm2Ckwz3KxvqK3IJ5JorBGJ0c7YT85B7L7L2gNSVTNZgZ1Afwr9J+hP4buEhwn1Eutj9tunOs9aIHbBTmvAPsRXojaNWhVfRRTf46ukJlgjHUI5Yc666iLYI9gj2CPYq7DPwRrB+AXGVRgj7XCZ637+lxGREZFRxUPyplkq3E/uDKqrOuaUJ0FjtTBbuRPYWfhC+EL4QvhC+J5RX0h9Ibwh9YVwh3CHcIe6aBfgf0mNZWosU2OJGovUGNI5OfuI113Y+NMl3jrHi7dRTR4PyWnWdUIep39OdU4VbcZpjMMSjmJcLKuHdYCoUY+6NMxfNWQ0uF2mui76x+cbc6+Bg9hFFx1Xsvvodomj52hEOIpAQhcrsVt0+tPsPsDfx6mZl8vZebRXcLNeSdKzCWcRpZrrnqRHFhxLkd2cNuG77nzn7GvnrRs/KdAaaAV0CXTJZVT+ZqwRq4O8Bam5jCS+/hKehn/2c96uDEM6zPB0lGF0nOErqxYUWpXTFrUpr60K1EGfdOoMr9Sjc9qtXo1orxd4gTK/AdqzpwkAAAAAAAABAAAAANWkJwgAAAAAyhUdMAAAAADSJwct")
+      format("woff");
+  font-weight: normal;
+  font-style: normal;
+  font-display: swap;
+}
+
+:root {
+  --default-font: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
+    "Segoe UI Symbol", "Microsoft YaHei Light", sans-serif;
+  --font-monospace: "Source Code Pro", monospace;
+  --preview-font: var(--default-font);
+  --editor-font: var(--default-font);
+  --header-font-pre: var(--preview-font);
+  --header-font-ed: var(--editor-font);
+  --mermaid-font: var(--font-monospace);
+
+  --base-h: 205;
+  --base-s: 23%;
+  --base-l: 94%;
+  --base-d: 5%;
+
+  --d-accent-h: 317;
+  --d-accent-s: 100%;
+  --d-accent-l: 90%;
+
+  --l-accent-h: 272;
+  --l-accent-s: 100%;
+  --l-accent-l: 84%;
+
+  --custom-line-indent: 40px;
+  --custom-pre-line-thickness: 1px;
+  --custom-ed-line-thickness: 1px;
+
+  --large-font-size: 18px;
+  --normal-font-size: 17px;
+  --medium-font-size: 16px;
+  --small-font-size: 15px;
+  --titlebar-height: 28px;
+  --line-width: 47rem;
+  --max-width: 97%;
+  --font-size-notes: 0.875rem;
+  --normal-weight: 400;
+  --bold-weight: 600;
+  --editor-font-size: 1rem;
+  --code-font-size: 0.9em;
+  --editor-line-height: 1.756666em;
+  --code-line-height: calc(var(--editor-line-height) - 0.25em);
+  --editor-font-weight: 400;
+
+  --strong-weight: var(--bold-weight);
+
+  --s-header-1-pre: 1.98em;
+  --s-header-2-pre: 1.88em;
+  --s-header-3-pre: 1.68em;
+  --s-header-4-pre: 1.48em;
+  --s-header-5-pre: 1.28em;
+  --s-header-6-pre: 1.08em;
+  --s-header-1-ed: 1.98rem;
+  --s-header-2-ed: 1.88rem;
+  --s-header-3-ed: 1.68rem;
+  --s-header-4-ed: 1.48rem;
+  --s-header-5-ed: 1.28rem;
+  --s-header-6-ed: 1.08rem;
+
+  --f-header-1-pre: var(--default-font);
+  --f-header-2-pre: var(--default-font);
+  --f-header-3-pre: var(--default-font);
+  --f-header-4-pre: var(--default-font);
+  --f-header-5-pre: var(--default-font);
+  --f-header-6-pre: var(--default-font);
+  --f-header-1-ed: var(--default-font);
+  --f-header-2-ed: var(--default-font);
+  --f-header-3-ed: var(--default-font);
+  --f-header-4-ed: var(--default-font);
+  --f-header-5-ed: var(--default-font);
+  --f-header-6-ed: var(--default-font);
+
+  /*----------------------------------------------------------------
+BASE COLORS
+----------------------------------------------------------------*/
+
+  --dark0: #2e3440;
+  --dark1: #3b4252;
+  --dark2: #434c5e;
+  --dark3: #4c566a;
+  --dark4: #0f0e14;
+  --dark5: #0b0b0b;
+
+  --light0: #d8dee9;
+  --light1: #e5e9f0;
+  --light2: #cacfd9;
+  --light3: #ffffff;
+  --light4: #f9fafb;
+  --light5: #eff1f5;
+
+  --frost0: #e69ca2;
+  --frost1: #88c0d0;
+  --frost2: #81a1c1;
+  --frost3: #f1ced0;
+
+  /*----------------------------------------------------------------
+COLORS
+----------------------------------------------------------------*/
+
+  --red: #ff5582;
+  --pink: #f2b3cf;
+  --fairpink: #eed3e1;
+  --yellow: #fff3a3;
+  --linen: #fcecec;
+  --paleblue: #bdd2ff;
+  --purple: #d2b3ff;
+  --palegreen: #a1ffa1;
+  --dusk: #474e5e;
+  --ash: #232630;
+  --cornflower-blue: #a1c4fd;
+  --light-cornflower-blue: #adccff;
+  --duskblue: #a2acc3;
+  --darkbrown: #34343d;
+  --pureblack: #080808;
+  --royalblue: #879bff;
+
+  /*----------------------------------------------------------------
+BOLD COLORS
+----------------------------------------------------------------*/
+
+  --boldpink: 310, 100%, 70%;
+  --boldpurple: #7322e6;
+  --boldred: #ff5555;
+  --boldyellow: #ffff00;
+  --boldorange: #ffb86c;
+  --boldgreen: #85ffa4;
+  --boldblue: #99e7ff;
+  --boldlightpink: 310, 100%, 84%;
+
+  /*----------------------------------------------------------------
+PASTEL COLORS
+----------------------------------------------------------------*/
+  --pastelyellow: #fcf4c9;
+  --pastelcoral: #ffe896;
+  --pastelpink: #fbcdf2;
+  --pastelpurple: #e8befa;
+  --pastelperiwinkle: #abbfff;
+  --pastelgreen: #bbf3c0;
+}
+
+.theme-dark {
+  --cerulean: #84b6ff;
+  --em-color: var(--cerulean);
+  --strong-color: hsl(var(--boldlightpink));
+  --accent-hsl: var(--d-accent-h), var(--d-accent-s), var(--d-accent-l);
+  --background-zero: hsla(
+    var(--base-h),
+    var(--base-s),
+    calc(var(--base-d) + 5%),
+    1
+  );
+  --background-primary: hsl(var(--base-h), var(--base-s), var(--base-d));
+  --background-primary-alt: hsla(
+    var(--base-h),
+    var(--base-s),
+    calc(var(--base-d) + 5%),
+    0.8
+  );
+  --background-secondary: hsl(
+    var(--base-h),
+    var(--base-s),
+    calc(var(--base-d) + 2%)
+  );
+  --background-secondary-alt: hsl(
+    var(--base-h),
+    var(--base-s),
+    calc(var(--base-d) + 2%)
+  );
+  --background-modifier-cover: hsla(
+    var(--base-h),
+    var(--base-s),
+    calc(var(--base-d) + 10%),
+    0.5
+  );
+  --background-modifier-error: #e60026;
+  --background-modifier-error-hover: red;
+  --background-modifier-border: hsl(
+    var(--base-h),
+    var(--base-s),
+    calc(var(--base-d) + 14%)
+  );
+  --background-modifier-form-field: var(--background-primary-alt);
+  --background-modifier-form-field-hover: var(--background-primary-alt);
+  --background-modifier-form-field-highlighted: var(--background-primary-alt);
+
+  --background-modifier-accent: hsl(
+    var(--d-accent-h),
+    var(--d-accent-s),
+    calc(var(--d-accent-l) - 7%)
+  );
+
+  --background-tertiary: hsl(
+    var(--base-h),
+    var(--base-s),
+    calc(var(--base-d) + 10%)
+  );
+  --background-transparent: hsla(
+    var(--base-h),
+    var(--base-s),
+    var(--base-d),
+    0
+  );
+  --background-translucent: hsla(
+    var(--base-h),
+    var(--base-s),
+    var(--base-d),
+    0.8
+  );
+  --background-match-highlight: hsla(var(--d-accent-h), 40%, 62%, 0.2);
+
+  --svg-faint: var(--text-faint);
+  --text-title-h1: var(--pink);
+  --text-title-h2: var(--purple);
+  --text-title-h3: var(--red);
+  --text-title-h4: var(--boldorange);
+  --text-title-h5: var(--boldgreen);
+  --text-title-h6: var(--paleblue);
+  --text-link: var(--frost0);
+  --text-a-hover: var(--pink);
+  --text-accent: hsl(
+    var(--d-accent-h),
+    var(--d-accent-s),
+    calc(var(--d-accent-l) - 2%)
+  );
+  --text-accent-hover: hsl(
+    var(--l-accent-h),
+    var(--l-accent-s),
+    calc(var(--d-accent-l) - 12%)
+  );
+  --text-on-accent: white;
+
+  --text-normal: hsla(
+    var(--base-h),
+    calc(var(--base-s) + 45%),
+    calc(var(--base-d) + 92%),
+    0.9
+  );
+  --text-muted: hsla(
+    var(--base-h),
+    calc(var(--base-s) - 1%),
+    calc(var(--base-d) + 58%),
+    1
+  );
+  --text-faint: hsla(
+    var(--base-h),
+    calc(var(--base-s) - 4%),
+    calc(var(--base-d) + 32%),
+    1
+  );
+
+  --interactive-accent: hsl(
+    var(--d-accent-h),
+    var(--d-accent-s),
+    var(--d-accent-l)
+  );
+  --interactive-accent-hover: hsl(
+    var(--d-accent-h),
+    var(--d-accent-s),
+    calc(var(--d-accent-l) - 5%)
+  );
+  --interactive-accent-rgb: 66, 66, 66;
+
+  --mod-button: hsl(var(--base-h), var(--base-s), calc(var(--base-d) + 3%));
+  --mod-button-hover: hsl(
+    var(--base-h),
+    var(--base-s),
+    calc(var(--base-d) + 4%)
+  );
+  --text-highlight-color: var(--text-normal);
+  --text-selection: hsl(var(--d-accent-h), 72%, 20%);
+  --tag-base: var(--background-primary);
+  --pre-code: hsl(
+    var(--base-h),
+    calc(var(--base-s) - 4%),
+    calc(var(--base-d) + 6%)
+  );
+  --inline-code: var(--light-cornflower-blue);
+  --code-block: var(--paleblue);
+  --code-block-border: var(--light0);
+  --vim-cursor: var(--interactive-accent);
+
+  --d-blockquote-h: 310;
+  --d-blockquote-s: 100%;
+  --d-blockquote-l: 84%;
+
+  --blockquote-border: var(--d-blockquote-h), var(--d-blockquote-s),
+    var(--d-blockquote-l);
+  --blockquote-bg: hsla(var(--blockquote-border), 0.05);
+
+  --checkbox-base: hsl(var(--base-h), var(--base-s), calc(var(--base-d) + 10%));
+  --checkbox-after: var(--interactive-accent);
+
+  --opacity-translucency: 1;
+
+  /*----------------------------------------------------------------
+HIGHLIGHTERS 
+----------------------------------------------------------------*/
+
+  --yellow-highlighter: #fff3a3a6;
+  --pink-highlighter: #ffb8eba6;
+  --red-highlighter: #ff5582a6;
+  --blue-highlighter: #adccffa6;
+  --green-highlighter: #bbfabba6;
+  --purple-highlighter: #d2b3ffa6;
+  --orange-highlighter: #ffb86ca6;
+  --grey-highlighter: #cacfd9a6;
+
+  --text-highlight-rgb: var(--pink-highlighter);
+
+  /*----------------------------------------------------------------
+DARK THEME GRAPH
+----------------------------------------------------------------*/
+
+  --graph-line: var(--background-modifier-border);
+  --graph-line-highlight: var(--interactive-accent-hover);
+  --graph-circle-outline: var(--text-faint);
+  --graph-fill-attachment: var(--em-color);
+  --graph-circle-fill: var(--text-normal);
+  --graph-circle-fill-highlight: var(--interactive-accent);
+  --graph-circle-fill-unresolved: hsl(var(--boldlightpink));
+  --graph-fill-tag: var(--background-modifier-accent);
+  --graph-arrow: hsl(var(--boldpink));
+}
+
+.theme-light {
+  --cerulean: #4a94ff;
+  --em-color: var(--cerulean);
+  --strong-color: hsl(var(--boldpink));
+  --accent-hsl: var(--l-accent-h), var(--l-accent-s), var(--l-accent-l);
+  --background-zero: hsla(
+    var(--base-h),
+    var(--base-s),
+    calc(var(--base-l) + 3%),
+    1
+  );
+  --background-primary: hsl(
+    var(--base-h),
+    var(--base-s),
+    calc(var(--base-l) + 5%)
+  );
+  --background-primary-alt: hsla(
+    var(--base-h),
+    var(--base-s),
+    calc(var(--base-l) + 1%),
+    0.75
+  );
+  --background-secondary: hsl(var(--base-h), var(--base-s), var(--base-l));
+  --background-secondary-alt: hsl(var(--base-h), var(--base-s), var(--base-l));
+  --background-modifier-cover: hsla(
+    var(--base-h),
+    var(--base-s),
+    calc(var(--base-d) + 90%),
+    0.5
+  );
+  --background-modifier-error: #e60026;
+  --background-modifier-error-hover: red;
+  --background-modifier-border: hsl(
+    var(--base-h),
+    var(--base-s),
+    calc(var(--base-l) - 4%)
+  );
+  --background-modifier-form-field: var(--background-primary);
+  --background-modifier-form-field-hover: var(--background-primary);
+  --background-modifier-form-field-highlighted: var(--background-primary);
+
+  --background-modifier-accent: hsl(
+    var(--l-accent-h),
+    var(--l-accent-s),
+    calc(var(--l-accent-l) - 10%)
+  );
+
+  --background-tertiary: hsl(
+    var(--base-h),
+    var(--base-s),
+    calc(var(--base-l) - 5%)
+  );
+  --background-transparent: hsla(
+    var(--base-h),
+    var(--base-s),
+    var(--base-l),
+    0
+  );
+  --background-translucent: hsla(
+    var(--base-h),
+    var(--base-s),
+    calc(var(--base-l) + 0%),
+    0.8
+  );
+  --background-match-highlight: hsla(var(--l-accent-h), 40%, 62%, 0.2);
+  --svg-faint: var(--text-faint);
+  --text-title-h1: hsl(var(--boldlightpink));
+  --text-title-h2: var(--purple);
+  --text-title-h3: var(--red);
+  --text-title-h4: var(--boldorange);
+  --text-title-h5: var(--boldgreen);
+  --text-title-h6: var(--cornflower-blue);
+  --text-link: var(--cornflower-blue);
+  --text-a-hover: var(--cornflower-blue);
+  --text-accent: hsl(
+    var(--l-accent-h),
+    var(--l-accent-s),
+    calc(var(--l-accent-l) - 5%)
+  );
+  --text-accent-hover: hsl(
+    var(--l-accent-h),
+    var(--l-accent-s),
+    calc(var(--l-accent-l) - 12%)
+  );
+  --text-on-accent: white;
+
+  --text-normal: hsl(var(--base-h), var(--base-s), calc(var(--base-l) - 79%));
+  --text-muted: hsl(
+    var(--base-h),
+    calc(var(--base-s) - 1%),
+    calc(var(--base-l) - 42%)
+  );
+  --text-faint: hsl(
+    var(--base-h),
+    calc(var(--base-s) - 2%),
+    calc(var(--base-l) - 20%)
+  );
+
+  --interactive-accent: hsl(
+    var(--l-accent-h),
+    var(--l-accent-s),
+    var(--l-accent-l)
+  );
+  --interactive-accent-hover: hsl(
+    var(--l-accent-h),
+    var(--l-accent-s),
+    calc(var(--l-accent-l) + 3%)
+  );
+  --interactive-accent-rgb: 200, 200, 200;
+  --mod-button: hsl(var(--base-h), var(--base-s), calc(var(--base-l) + 2%));
+  --mod-button-hover: hsl(
+    var(--base-h),
+    var(--base-s),
+    calc(var(--base-l) + 3%)
+  );
+
+  --text-highlight-color: var(--text-normal);
+  --text-selection: hsl(var(--l-accent-h), var(--l-accent-s), 94.5%);
+
+  --tag-base: var(--background-primary);
+  --pre-code: hsl(
+    var(--base-h),
+    calc(var(--base-s) - 8%),
+    calc(var(--base-l) + 1%)
+  );
+  --inline-code: var(--royalblue);
+  --code-block: var(--frost2);
+  --code-block-border: var(--light2);
+  --vim-cursor: var(--interactive-accent);
+
+  --l-blockquote-h: 310;
+  --l-blockquote-s: 100%;
+  --l-blockquote-l: 70%;
+
+  --blockquote-border: var(--l-blockquote-h), var(--l-blockquote-s),
+    var(--l-blockquote-l);
+  --blockquote-bg: hsla(var(--blockquote-border), 0.05);
+
+  --checkbox-base: hsl(
+    var(--base-h),
+    calc(var(--base-s) - 8%),
+    calc(var(--base-l) - 5%)
+  );
+  --checkbox-after: var(--interactive-accent);
+
+  --opacity-translucency: 1;
+
+  /*----------------------------------------------------------------
+HIGHLIGHTERS 
+----------------------------------------------------------------*/
+
+  --yellow-highlighter: #fff3a3a6;
+  --pink-highlighter: #ffb8eba6;
+  --red-highlighter: #ff5582a6;
+  --blue-highlighter: #adccffa6;
+  --green-highlighter: #bbfabba6;
+  --purple-highlighter: #d2b3ffa6;
+  --orange-highlighter: #ffb86ca6;
+  --grey-highlighter: #cacfd9a6;
+
+  --text-highlight-rgb: var(--yellow-highlighter);
+
+  /*----------------------------------------------------------------
+LIGHT THEME GRAPH
+----------------------------------------------------------------*/
+
+  --graph-line: var(--text-muted);
+  --graph-line-highlight: var(--interactive-accent-hover);
+  --graph-circle-outline: var(--text-faint);
+  --graph-fill-attachment: var(--em-color);
+  --graph-circle-fill: var(--text-normal);
+  --graph-circle-fill-highlight: var(--interactive-accent);
+  --graph-circle-fill-unresolved: var(--text-normal);
+  --graph-fill-tag: var(--background-modifier-accent);
+  --graph-arrow: var(--boldpurple);
+}
+
+/*----------------------------------------------------------------
+FOR EXPORT
+----------------------------------------------------------------*/
+
+@media print {
+  p {
+    color: black !important;
+  }
+  ul > li::before,
+  ol > li::before {
+    border-left: 1px solid #ecedf1;
+  }
+  code,
+  pre code,
+  code[class*="language-"],
+  pre code[class*="language-"] {
+    background-color: #fcfcfd !important;
+  }
+  .markdown-preview-view mark {
+    color: black !important;
+  }
+  .markdown-preview-view pre {
+    background-color: #fcfcfd;
+  }
+  .copy-code-button {
+    display: none;
+  }
+  .theme-dark {
+    --background-modifier-border: #ecedf1;
+    --pre-code: hsl(
+      var(--base-h),
+      calc(var(--base-s) - 8%),
+      calc(var(--base-l) + 1%)
+    );
+  }
+  aside {
+    color: black !important;
+  }
+}
+
+@media print {
+  /* revise blockquote colour and border in pdf exporting */
+  .print .markdown-preview-view blockquote {
+    line-height: var(--editor-line-height);
+    color: #000000; 
+    font-family: var(--default-font);
+    border: none;
+    /* border-left: 0.3rem solid #737373; */
+    background-color: #FFFFFF00;
+    /* border-radius: 0px; */
+    margin: 1rem 0rem 1rem 0rem;
+    padding: 2rem;
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+  }
+
+  /* unlimited embedded box height in pdf exporting */
+  .print .markdown-preview-view .markdown-embed-content > .markdown-preview-view {
+    max-height: none !important;
+  }
+
+  /* revise external links colour in pdf exporting */
+  .print .markdown-preview-view .external-link {
+    color: var(--text-normal);
+  }
+
+  /* revise heading 1~6 sizes in pdf exporting */
+  .print .markdown-preview-view h1 {
+    line-height: 1.2em;
+    font-weight: 750;
+    font-size: var(--s-header-1-pre);
+    color: var(--text-normal);
+  }
+
+  .print .markdown-preview-view h2 {
+    line-height: 1.2em;
+    font-weight: 700;
+    font-size: var(--s-header-2-pre);
+    color: var(--text-normal);
+  }
+
+  .print .markdown-preview-view h3 {
+    line-height: 1.2em;
+    font-weight: 650;
+    font-size: var(--s-header-3-pre);
+    color: var(--text-normal);
+  }
+
+  .print .markdown-preview-view h4 {
+    font-weight: 650;
+    font-size: var(--s-header-4-pre);
+    color: var(--text-normal);
+  }
+
+  .print .markdown-preview-view h5 {
+    line-height: 1.2em;
+    font-weight: 650;
+    font-size: var(--s-header-5-pre);
+    color: var(--text-normal);
+  }
+
+  .print .markdown-preview-view h6 {
+    font-weight: 600;
+    font-size: var(--s-header-6-pre);
+    color: var(--text-normal);
+  }
+}
+
+/*----------------------------------------------------------------
+TITLEBAR
+----------------------------------------------------------------*/
+
+/* revise the note tab style to simple rounded rectangle */
+.workspace-split.mod-root .workspace-tab-header.is-active::before, .workspace-split.mod-root .workspace-tab-header.is-active::after {
+  box-shadow: unset;
+  /*box-shadow: inset 0 0 0 var(--tab-outline-width) var(--tab-outline-color), 0 0 0 calc(var(--tab-curve) * 4) var(--tab-background-active);*/
+}
+
+/* align the top-lines of the note and the sidebars */
+/*body:not(.hider-frameless):not(.is-fullscreen):not(.is-mobile) {
+  padding-top: var(--titlebar-height) !important;
+}*/
+
+.hider-frameless .titlebar,
+.hider-frameless .titlebar-inner {
+  position: fixed;
+  top: 0;
+  height: 12px;
+  background: transparent !important;
+}
+
+.titlebar {
+  background: var(--background-secondary-alt);
+  height: var(--titlebar-height) !important;
+}
+
+.no-show-titlebar-text .titlebar-text {
+  display: none;
+}
+
+.titlebar-button-container {
+  height: var(--titlebar-height);
+  top: 0;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+}
+
+.titlebar-inner {
+  height: var(--titlebar-height);
+  color: var(--text-muted);
+}
+
+.titlebar-button {
+  cursor: pointer;
+  /*padding-top: 5px;*/
+}
+
+.titlebar-button:hover {
+  color: pink;
+}
+
+.titlebar-button-container.mod-left:hover {
+  cursor: pointer !important;
+  opacity: 1;
+}
+
+.titlebar-button-container.mod-left {
+  opacity: 0;
+  transition: opacity 100ms ease-in-out;
+}
+
+/*----------------------------------------------------------------
+FOUNDATIONS
+----------------------------------------------------------------*/
+.view-header-title,
+.vertical-tab-content h2,
+.setting-item-heading,
+.vertical-tab-header-group-title,
+.app-container.is-left-sidedock-collapsed .workspace-split.mod-left-split,
+.app-container.is-right-sidedock-collapsed .workspace-split.mod-right-split {
+  font-family: var(--default-font);
+}
+
+textarea {
+  font-family: inherit;
+  font-size: inherit;
+}
+
+html {
+  font-size: var(--editor-font-size);
+}
+
+body {
+  --preview-font-size: var(--editor-font-size);
+  --preview-line-height: var(--editor-line-height);
+  --preview-font-weight: var(--editor-font-weight);
+}
+
+.markdown-preview-view {
+  font-family: var(--preview-font);
+  font-size: var(--preview-font-size);
+  font-weight: var(--preview-font-weight);
+  line-height: var(--preview-line-height);
+}
+
+.CodeMirror pre.CodeMirror-line,
+.markdown-source-view,
+.cm-s-obsidian {
+  font-size: var(--editor-font-size);
+  font-weight: var(--editor-font-weight);
+  line-height: var(--editor-line-height);
+}
+
+.cm-line,
+.markdown-source-view,
+.cm-s-obsidian {
+  font-family: var(--editor-font);
+}
+
+body,
+.app-container {
+  color: var(--text-normal);
+  text-rendering: optimizeLegibility;
+  -webkit-font-feature-settings: "tnum";
+  -moz-font-feature-settings: "tnum";
+  font-feature-settings: "tnum";
+  -webkit-font-variant-numeric: tabular-nums;
+  -moz-font-variant-numeric: tabular-nums;
+  font-variant-numeric: tabular-nums;
+}
+
+body,
+input,
+textarea,
+button,
+.cm-s-obsidian .cm-formatting-hashtag,
+.cm-s-obsidian,
+.app-container,
+.CodeMirror-scroll,
+.CodeMirror-sizer,
+.CodeMirror-gutter,
+.CodeMirror-gutters,
+.CodeMirror-linenumber {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-variant-ligatures: common-ligatures;
+}
+
+/* PRIMARY FONT SIZING & STYLING */
+
+/*FONT SIZE*/
+.search-input-container input,
+.workspace-leaf-content .search-input,
+.footnotes-list,
+.markdown-preview-section .frontmatter code,
+body:not(.is-mobile) .vertical-tab-nav-item,
+.frontmatter-container .tag,
+h1 .tag,
+h2 .tag,
+h3 .tag,
+h4 .tag,
+h5 .tag,
+h6 .tag,
+ul .tag,
+p .tag,
+.cm-s-obsidian .cm-hmd-frontmatter,
+.cm-s-obsidian pre.HyperMD-footnote,
+.tree-item-self,
+.tooltip,
+.outline .pane-empty,
+.document-search-button,
+.cm-s-obsidian pre.HyperMD-footnote {
+  font-size: 0.875em !important;
+}
+
+/* FONT STYLING */
+.cm-s-obsidian .hmd-fold-html-stub,
+.cm-s-obsidian .hmd-fold-code-stub,
+.cm-s-obsidian.CodeMirror .HyperMD-hover > .HyperMD-hover-content code,
+.cm-s-obsidian .cm-formatting-hashtag,
+.cm-s-obsidian .cm-inline-code,
+.cm-s-obsidian .HyperMD-codeblock,
+.cm-s-obsidian .HyperMD-hr,
+.cm-s-obsidian .cm-hmd-frontmatter,
+.cm-s-obsidian .cm-hmd-orgmode-markup,
+.cm-s-obsidian .cm-formatting-code,
+.cm-s-obsidian .cm-math,
+.cm-s-obsidian span.hmd-fold-math-placeholder,
+.cm-s-obsidian .CodeMirror-linewidget kbd,
+.cm-s-obsidian .hmd-fold-html kbd {
+  font-weight: normal;
+  color: var(--text-muted);
+  letter-spacing: 0;
+}
+
+/*INPUT STYLING,*/
+
+input {
+  font-family: var(--default-font);
+}
+
+input[type="text"],
+input[type="search"],
+input[type="email"],
+input[type="password"],
+input[type="number"] {
+  -webkit-appearance: none;
+  transition: all 0.1s linear;
+}
+
+input[type="text"],
+input[type="email"],
+input[type="password"],
+input[type="number"],
+input[type="search"],
+.splash-brand-name,
+.dropdown,
+.setting-hotkey,
+.suggestion-hotkey {
+  font-family: var(--default-font) !important;
+  font-size: 0.875rem;
+  border: 1px solid var(--background-modifier-border) !important;
+}
+
+input[type="text"] {
+  height: 2.7em;
+}
+
+input[type="text"],
+input[type="email"],
+input[type="password"],
+input[type="number"],
+input[type="search"],
+.splash-brand-name {
+  min-height: 2.4em;
+  /*height: auto;*/ /* solve over enlarged prompt-input */
+}
+
+input[type="text"],
+input[type="search"],
+input[type="email"],
+input[type="password"],
+input[type="number"] {
+  font-family: var(--default-font) !important;
+  font-size: 100%; /*INPUT TEXT SIZE*/
+  color: var(--text-muted);
+  border-radius: 5px;
+}
+
+/* remove prompt-input padding */
+/*input.prompt-input,
+input.prompt-input:hover {
+  padding-left: 10px;
+  box-shadow: unset;
+}*/
+
+/*Focus Input */
+
+textarea:focus {
+  box-shadow: 0 0 0 0.1px rgba(0, 0, 0, 0.1),
+    0 0 0 3px hsla(var(--accent-hsl), 0.35);
+  border: 1px solid var(--interactive-accent) !important;
+}
+
+textarea {
+  outline: 0;
+  padding: 10px 10px;
+  padding: 5px 10px;
+  height: auto;
+}
+
+input[type="text"]:focus-within,
+input[type="search"]:focus-within,
+input[type="email"]:focus-within,
+input[type="password"]:focus-within,
+input[type="number"]:focus-within {
+  font-family: var(--default-font) !important;
+  color: var(--text-normal);
+  border: 1px solid var(--text-muted);
+}
+
+input[type="text"]:active,
+input[type="search"]:active,
+input[type="email"]:active,
+input[type="password"]:active,
+input[type="number"]:active,
+input[type="text"]:focus,
+input[type="search"]:focus,
+input[type="email"]:focus,
+input[type="password"]:focus,
+input[type="number"]:focus {
+  border: 1px solid var(--interactive-accent) !important;
+}
+
+.graph-controls .search-input-container input:focus,
+.workspace-leaf-content .search-input-container input:focus {
+  border: 1px solid var(--interactive-accent);
+}
+
+input.search-input:focus {
+  border: 1px solid var(--interactive-accent);
+}
+
+.modal-content input {
+  border-style: none;
+  border-radius: 5px;
+}
+
+.modal-content h4 {
+  font-size: var(--s-header-4-pre);
+}
+
+.templater-prompt-input:focus,
+.dropdown:focus,
+input:not(input[type="range"]):focus,
+.search-result-file-match:not(.search-info-more-matches):hover {
+  box-shadow: 0 0 0 0.1px rgba(0, 0, 0, 0.1),
+    0 0 0 2px hsla(var(--accent-hsl), 0.35);
+  border: 1px solid var(--interactive-accent) !important;
+  border-radius: 10px; /* solve focus prompt-input border break */
+}
+
+.workspace-split.mod-root .search-result-file-match:hover,
+.search-result-file-match:not(.search-info-more-matches):hover {
+  background-color: var(--background-zero);
+}
+
+input.document-search-input,
+input.document-replace-input,
+input.document-search-input.mod-no-match:focus,
+input.document-replace-input.mod-no-match:focus,
+input.document-search-input.mod-no-match:hover,
+input.document-replace-input.mod-no-match:hover {
+  transition: background 0.5s ease-in-out;
+}
+
+input.document-search-input:focus,
+input.document-replace-input:focus {
+  transition: all 0.5s ease-in-out;
+  border: 1px solid var(--interactive-accent);
+}
+
+/*----------------------------------------------------------------
+SECONDARY FOUNDATIONS 
+----------------------------------------------------------------*/
+
+.CodeMirror-gutter.CodeMirror-linenumbers,
+.CodeMirror-gutter.CodeMirror-foldgutter {
+  background: transparent;
+}
+
+p,
+.CodeMirror pre.CodeMirror-line {
+  line-height: var(--editor-line-height);
+  padding-top: 0px;
+  padding-bottom: 0px;
+  margin-inline-start: 0px;
+  margin-inline-end: 0px;
+}
+
+ul .task-list-item,
+ol,
+ul {
+  font-family: var(--preview-font);
+}
+
+.markdown-embed .markdown-preview-section:last-child p,
+.markdown-embed .markdown-preview-section:last-child ul {
+  margin-block-end: 2px;
+}
+
+p.mod-warning {
+  color: red;
+}
+
+/*line height for checklists in preview*/
+ul .task-list-item {
+  line-height: 1em !important;
+}
+
+/*line height for lists in preview*/
+.markdown-preview-view ol,
+.markdown-preview-view ul {
+  padding-top: 0px;
+  padding-bottom: 0px;
+  display: block;
+  line-height: var(--editor-line-height);
+  padding-inline-start: var(--custom-line-indent);
+}
+
+/*GRAPH HEADERS*/
+
+.graph-control-section-header {
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.graph-controls .setting-item-name {
+  color: var(--text-muted);
+  display: inline-block;
+}
+
+/*GRAPH SETTINGS*/
+
+.graph-controls-button.mod-animate {
+  margin-top: 0;
+}
+
+.graph-controls .search-input-container {
+  width: 100%;
+}
+
+.graph-controls.is-close {
+  border-radius: 6px;
+  border: 0px solid var(--background-secondary);
+  box-shadow: 0px 0px 0px 0.1px inset var(--background-tertiary),
+    0px 0px 1px 1px inset var(--background-tertiary);
+  padding: 0;
+  line-height: 1;
+}
+
+.theme-dark .graph-controls.is-close {
+  box-shadow: 0px 0px 0px 1px inset var(--background-tertiary),
+    0px 0px 1px 1px inset var(--background-tertiary);
+}
+
+.graph-controls .tree-item-collapse {
+  color: var(--text-normal);
+  padding: 0;
+  position: static;
+  line-height: 1;
+  display: flex;
+}
+
+.graph-controls.is-close .graph-controls-button.mod-open,
+.graph-controls:not(.is-close) .graph-controls-button.mod-reset,
+.graph-controls:not(.is-close) .graph-controls-button.mod-close,
+.graph-controls:not(.is-close):hover .graph-controls-button.mod-reset,
+.graph-controls:not(.is-close):hover .graph-controls-button.mod-close {
+  display: flex;
+}
+
+.graph-controls-button:hover {
+  color: var(--text-normal);
+  border-radius: 4px;
+}
+
+.graph-controls-button.mod-reset {
+  top: 5px;
+  right: 26px;
+  font-size: 14px;
+  height: 14px;
+  width: 14px;
+}
+
+.graph-controls.is-close .graph-controls-button {
+  padding: 9px 9px;
+}
+
+.graph-controls-button {
+  color: var(--text-muted);
+}
+
+.graph-controls {
+  top: 10px;
+  left: 10px;
+  opacity: 0.9;
+  border: 1px solid var(--background-modifier-border);
+  background: var(--background-primary-alt);
+  font-weight: 500;
+  border-radius: 6px;
+  min-width: 124px;
+  max-width: 228px;
+  box-shadow: 0 2px 6px 0 var(--background-tertiary);
+  padding: 18px 18px 18px 8px;
+  max-height: calc(100% - 16px);
+}
+
+.theme-dark .graph-controls.is-close {
+  background: var(--background-primary);
+}
+
+.theme-dark .graph-controls {
+  background-color: var(--background-primary-alt);
+}
+
+.graph-controls {
+  background-color: var(--background-primary);
+}
+
+/* TOOLTIP */
+
+/* LIGHT TOOLTIP */
+.tooltip {
+  font-weight: 500;
+  font-family: var(--default-font);
+}
+
+.tooltip {
+  background-color: var(--background-primary);
+  color: var(--text-normal);
+}
+
+.tooltip .tooltip-arrow {
+  position: absolute;
+  top: -5px;
+  left: 50%;
+  width: 0;
+  margin-left: -5px;
+  border-bottom: 5px solid var(--background-primary);
+  border-right: 5px solid transparent;
+  border-left: 5px solid transparent;
+  content: " ";
+  font-size: 0;
+  line-height: 0;
+}
+
+.tooltip.mod-right .tooltip-arrow {
+  top: calc(50% - 5px);
+  left: -5px;
+  border-right: 5px solid var(--background-primary);
+  border-top: 5px solid transparent;
+  border-bottom: 5px solid transparent;
+}
+
+.tooltip.mod-left .tooltip-arrow {
+  top: calc(50% - 5px);
+  left: calc(100% + 5px);
+  border-left: 5px solid var(--background-primary);
+  border-top: 5px solid transparent;
+  border-bottom: 5px solid transparent;
+}
+
+.tooltip.mod-top .tooltip-arrow {
+  top: calc(100%);
+  border-top: 5px solid var(--background-primary);
+  border-bottom: 5px solid transparent;
+}
+
+/* LOADING BARS */
+
+.is-loading:before,
+.search-result-container.is-loading:before {
+  background-color: var(--background-modifier-accent); /*#change*/
+  animation: 1000ms ease-in-out 300ms infinite progress-bar;
+}
+
+/*Vault Launch Progress Bar */
+
+.progress-bar {
+  background-color: var(--background-zero);
+  border: 1px solid var(--background-modifier-border);
+}
+
+.theme-light .progress-bar {
+  background-color: var(--background-zero);
+  border: 1px solid var(--background-modifier-border);
+}
+
+.progress-bar-message {
+  color: var(--text-muted);
+}
+
+.progress-bar-subline {
+  position: absolute;
+  background-color: var(--interactive-accent);
+  border-radius: 0px !important;
+  height: 8px;
+}
+
+.progress-bar-line {
+  position: absolute;
+  background-color: var(--interactive-accent-hover);
+  width: 150%;
+  border-radius: 0px !important;
+  height: 8px;
+}
+
+/*INPUT - RANGE*/
+
+input[type="range"] {
+  background-color: transparent;
+  height: 24px;
+  padding: 0px !important;
+  -webkit-appearance: none;
+  cursor: default;
+  border-radius: 90px;
+}
+
+input[type="range"]::-webkit-slider-runnable-track {
+  background: var(--background-modifier-border);
+  height: 1px !important;
+}
+
+input[type="range"]::-webkit-slider-thumb {
+  height: 9px;
+  width: 20px;
+  margin-top: -1px;
+  cursor: ew-resize;
+  transition: 500ms;
+  border-radius: 2px;
+  background: hsl(var(--accent-hsl));
+  box-shadow: 0px 3px 6px rgb(10 15 73 / 10%),
+    0 0 0 0.5px var(--background-modifier-border),
+    inset 0 -1px 2px rgb(10 15 73 / 8%);
+  border: 1px solid transparent;
+}
+
+input[type="range"]::-webkit-slider-thumb:hover,
+input[type="range"]::-webkit-slider-thumb:active {
+  background: var(--interactive-accent-hover);
+  border-width: 1;
+  border: 1px solid transparent;
+  transition: all 0.1s linear;
+}
+
+.graph-controls input[type="range"]::-webkit-slider-runnable-track {
+  margin-top: -5px;
+}
+
+/*CHECKBOXES*/
+
+.checkbox-container {
+  cursor: pointer;
+  background-color: var(--checkbox-base);
+  border-radius: 5px;
+  display: inline-block;
+  height: 23px;
+  position: relative;
+  user-select: none;
+  width: 42px;
+  box-shadow: inset 0px 0px 3px rgba(0, 0, 0, 0.055);
+  transition: background 0.15s ease-in-out, box-shadow 0.15s ease-in-out,
+    border 0.15s ease-in-out, opacity 0.15s ease-in-out,
+    -webkit-box-shadow 0.15s ease-in-out;
+}
+
+.checkbox-container:after {
+  pointer-events: none;
+  content: "";
+  display: inline-block;
+  position: absolute;
+  background-color: var(--background-primary);
+  width: 15px;
+  height: 16px;
+  margin: 3px;
+  left: 0;
+  border-radius: 3px;
+  transition: transform 0.15s ease-in-out, width 0.1s ease-in-out,
+    left 0.1s ease-in-out, -webkit-transform 0.15s ease-in-out;
+  transform: translate3d(1px, 0, 0);
+  box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.1),
+    inset 0 0px 1px rgba(0, 0, 0, 0.15), 0 0 0 1px rgba(0, 0, 0, 0.03);
+}
+
+.checkbox-container.is-enabled:after {
+  transform: translate3d(20px, 0, 0);
+}
+
+.checkbox-container.is-enabled {
+  background-color: var(--checkbox-after);
+}
+
+.theme-dark .checkbox-container:after {
+  background-color: #f8f8f8;
+}
+
+/*----------------------------------------------------------------
+HEADINGS
+----------------------------------------------------------------*/
+
+.cm-s-obsidian .HyperMD-header {
+  line-height: 1.2 !important;
+  font-family: inherit !important;
+}
+
+.markdown-source-view:not(.mod-cm6.cm-s-obsidian)
+  .cm-s-obsidian
+  .cm-header:is(.cm-header-1, .cm-header-2, .cm-header-3, .cm-header-4, .cm-header-5, .cm-header-6) {
+  font-size: inherit;
+  font-weight: inherit;
+}
+
+.cm-s-obsidian .cm-header.cm-header-1,
+.cm-s-obsidian .cm-header.cm-header-2,
+.cm-s-obsidian .cm-header.cm-header-3,
+.cm-s-obsidian .cm-header.cm-header-4,
+.cm-s-obsidian .cm-header.cm-header-5,
+.cm-s-obsidian .cm-header.cm-header-6 {
+  font-family: var(--header-font-ed);
+  color: inherit;
+  font-style: inherit;
+  line-height: inherit;
+}
+
+.markdown-preview-view h1,
+.markdown-preview-view h2,
+.markdown-preview-view h3,
+.markdown-preview-view h4,
+.markdown-preview-view h5,
+.markdown-preview-view h6 {
+  font-family: var(--header-font-pre);
+}
+
+body.is-mobile .HyperMD-header-1,
+.CodeMirror .CodeMirror-line.HyperMD-header-1,
+.markdown-preview-section h1 {
+  line-height: 1.2em;
+  font-weight: 750;
+  font-size: var(--s-header-1-pre);
+  color: var(--text-normal);
+}
+
+body.is-mobile .HyperMD-header-2,
+.CodeMirror .CodeMirror-line.HyperMD-header-2,
+.markdown-preview-section h2 {
+  line-height: 1.2em;
+  font-weight: 700;
+  font-size: var(--s-header-2-pre);
+  color: var(--text-normal);
+}
+
+body.is-mobile .HyperMD-header-3,
+.CodeMirror .CodeMirror-line.HyperMD-header-3,
+.markdown-preview-section h3 {
+  line-height: 1.2em;
+  font-weight: 650;
+  font-size: var(--s-header-3-pre);
+  color: var(--text-normal);
+}
+
+body.is-mobile .HyperMD-header-4,
+.CodeMirror .CodeMirror-line.HyperMD-header-4,
+.markdown-preview-section h4 {
+  font-weight: 650;
+  font-size: var(--s-header-4-pre);
+  color: var(--text-normal);
+}
+
+body.is-mobile .HyperMD-header-5,
+.CodeMirror .CodeMirror-line.HyperMD-header-5,
+.markdown-preview-section h5 {
+  line-height: 1.2em;
+  font-weight: 650;
+  font-size: var(--s-header-5-pre);
+  color: var(--text-normal);
+}
+
+body.is-mobile .HyperMD-header-6,
+.CodeMirror .CodeMirror-line.HyperMD-header-6,
+.markdown-preview-section h6 {
+  font-weight: 600;
+  font-size: var(--s-header-6-pre);
+  color: var(--text-normal);
+}
+
+/*----------------------------------------------------------------
+SPECIFIC HEADINGS
+----------------------------------------------------------------*/
+
+.spec-font-head .markdown-preview-view h1 {
+  font-family: var(--f-header-1-pre);
+}
+
+.spec-font-head .markdown-preview-section h2 {
+  font-family: var(--f-header-2-pre);
+}
+
+.spec-font-head .markdown-preview-section h3 {
+  font-family: var(--f-header-3-pre);
+}
+
+.spec-font-head .markdown-preview-section h4 {
+  font-family: var(--f-header-4-pre);
+}
+
+.spec-font-head .markdown-preview-section h5 {
+  font-family: var(--f-header-5-pre);
+}
+
+.spec-font-head .markdown-preview-section h6 {
+  font-family: var(--f-header-6-pre);
+}
+
+.spec-font-head .cm-s-obsidian .cm-header.cm-header-1 {
+  font-family: var(--f-header-1-ed);
+}
+
+.spec-font-head .cm-s-obsidian .cm-header.cm-header-2 {
+  font-family: var(--f-header-2-ed);
+}
+
+.spec-font-head .cm-s-obsidian .cm-header.cm-header-3 {
+  font-family: var(--f-header-3-ed);
+}
+
+.spec-font-head .cm-s-obsidian .cm-header.cm-header-4 {
+  font-family: var(--f-header-4-ed);
+}
+
+.spec-font-head .cm-s-obsidian .cm-header.cm-header-5 {
+  font-family: var(--f-header-5-ed);
+}
+
+.spec-font-head .cm-s-obsidian .cm-header.cm-header-6 {
+  font-family: var(--f-header-6-ed);
+}
+
+.spec-size-head .markdown-preview-section h1 {
+  font-size: var(--s-header-1-pre);
+}
+
+.spec-size-head .markdown-preview-section h2 {
+  font-size: var(--s-header-2-pre);
+}
+
+.spec-size-head .markdown-preview-section h3 {
+  font-size: var(--s-header-3-pre);
+}
+
+.spec-size-head .markdown-preview-section h4 {
+  font-size: var(--s-header-4-pre);
+}
+
+.spec-size-head .markdown-preview-section h5 {
+  font-size: var(--s-header-5-pre);
+}
+
+.spec-size-head .markdown-preview-section h6 {
+  font-size: var(--s-header-6-pre);
+}
+
+.spec-size-head body.is-mobile .HyperMD-header-1,
+.spec-size-head .CodeMirror .CodeMirror-line.HyperMD-header-1 {
+  font-size: var(--s-header-1-ed);
+}
+
+.spec-size-head body.is-mobile .HyperMD-header-2,
+.spec-size-head .CodeMirror .CodeMirror-line.HyperMD-header-2 {
+  font-size: var(--s-header-2-ed);
+}
+
+.spec-size-head body.is-mobile .HyperMD-header-3,
+.spec-size-head .CodeMirror .CodeMirror-line.HyperMD-header-3 {
+  font-size: var(--s-header-3-ed);
+}
+
+.spec-size-head body.is-mobile .HyperMD-header-4,
+.spec-size-head .CodeMirror .CodeMirror-line.HyperMD-header-4 {
+  font-size: var(--s-header-4-ed);
+}
+
+.spec-size-head body.is-mobile .HyperMD-header-5,
+.spec-size-head .CodeMirror .CodeMirror-line.HyperMD-header-5 {
+  font-size: var(--s-header-5-ed);
+}
+
+.spec-size-head body.is-mobile .HyperMD-header-6,
+.spec-size-head .CodeMirror .CodeMirror-line.HyperMD-header-6 {
+  font-size: var(--s-header-6-ed);
+}
+
+.spec-color-head .markdown-preview-section h1 {
+  color: var(--sphd-pre-1);
+}
+
+.spec-color-head .markdown-preview-section h2 {
+  color: var(--sphd-pre-2);
+}
+
+.spec-color-head .markdown-preview-section h3 {
+  color: var(--sphd-pre-3);
+}
+
+.spec-color-head .markdown-preview-section h4 {
+  color: var(--sphd-pre-4);
+}
+
+.spec-color-head .markdown-preview-section h5 {
+  color: var(--sphd-pre-5);
+}
+
+.spec-color-head .markdown-preview-section h6 {
+  color: var(--sphd-pre-6);
+}
+
+.spec-color-head
+  .cm-s-obsidian
+  .cm-header:not(.cm-hastag):not(.cm-em).cm-header-1:not(.cm-hmd-internal-link) {
+  color: var(--sphd-ed-1);
+}
+
+.spec-color-head
+  .cm-s-obsidian
+  .cm-header:not(.cm-hastag):not(.cm-em).cm-header-2:not(.cm-hmd-internal-link) {
+  color: var(--sphd-ed-2);
+}
+
+.spec-color-head
+  .cm-s-obsidian
+  .cm-header:not(.cm-hastag):not(.cm-em).cm-header-3:not(.cm-hmd-internal-link) {
+  color: var(--sphd-ed-3);
+}
+
+.spec-color-head
+  .cm-s-obsidian
+  .cm-header:not(.cm-hastag):not(.cm-em).cm-header-4:not(.cm-hmd-internal-link) {
+  color: var(--sphd-ed-4);
+}
+
+.spec-color-head
+  .cm-s-obsidian
+  .cm-header:not(.cm-hastag):not(.cm-em).cm-header-5:not(.cm-hmd-internal-link) {
+  color: var(--sphd-ed-5);
+}
+
+.spec-color-head
+  .cm-s-obsidian
+  .cm-header:not(.cm-hastag):not(.cm-em).cm-header-6:not(.cm-hmd-internal-link) {
+  color: var(--sphd-ed-6);
+}
+
+.community-plugin-readme.markdown-preview-view h1:first-child,
+.community-plugin-readme.markdown-preview-view h2:first-child,
+.community-plugin-readme.markdown-preview-view h3:first-child,
+.community-plugin-readme.markdown-preview-view h4:first-child,
+.community-plugin-readme.markdown-preview-view h5:first-child,
+.community-plugin-readme.markdown-preview-view h6:first-child,
+.markdown-preview-pusher + div > h1,
+.markdown-preview-pusher + div > h2,
+.markdown-preview-pusher + div > h3,
+.markdown-preview-pusher + div > h4,
+.markdown-preview-pusher + div > h5,
+.markdown-preview-pusher + div > h6,
+.markdown-preview-pusher + div:empty + div > h1,
+.markdown-preview-pusher + div:empty + div > h2,
+.markdown-preview-pusher + div:empty + div > h3,
+.markdown-preview-pusher + div:empty + div > h4,
+.markdown-preview-pusher + div:empty + div > h5,
+.markdown-preview-pusher + div:empty + div > h6,
+.markdown-preview-pusher + div[data-tag-name="pre"] + div > h1,
+.markdown-preview-pusher + div[data-tag-name="pre"] + div > h2,
+.markdown-preview-pusher + div[data-tag-name="pre"] + div > h3,
+.markdown-preview-pusher + div[data-tag-name="pre"] + div > h4,
+.markdown-preview-pusher + div[data-tag-name="pre"] + div > h5,
+.markdown-preview-pusher + div[data-tag-name="pre"] + div > h6 {
+  margin-top: 0 !important;
+}
+
+/*----------------------------------------------------------------
+Inline code in headers to match header size
+*/
+
+.cm-s-obsidian
+  span.cm-inline-code.cm-header-1:not(.cm-formatting):not(.cm-hmd-indented-code):not(.obsidian-search-match-highlight),
+.cm-s-obsidian span.cm-inline-code.cm-header-1 {
+  font-family: var(--font-monospace) !important;
+  background-color: var(--pre-code) !important;
+  font-weight: inherit !important;
+}
+
+.cm-s-obsidian
+  span.cm-inline-code.cm-header-2:not(.cm-formatting):not(.cm-hmd-indented-code):not(.obsidian-search-match-highlight),
+.cm-s-obsidian span.cm-inline-code.cm-header-2 {
+  font-family: var(--font-monospace) !important;
+  background-color: var(--pre-code) !important;
+  font-weight: inherit !important;
+}
+
+.cm-s-obsidian
+  span.cm-inline-code.cm-header-3:not(.cm-formatting):not(.cm-hmd-indented-code):not(.obsidian-search-match-highlight),
+.cm-s-obsidian span.cm-inline-code.cm-header-3 {
+  font-family: var(--font-monospace) !important;
+  background-color: var(--pre-code) !important;
+  font-weight: inherit !important;
+}
+
+.cm-s-obsidian
+  span.cm-inline-code.cm-header-4:not(.cm-formatting):not(.cm-hmd-indented-code):not(.obsidian-search-match-highlight),
+.cm-s-obsidian span.cm-inline-code.cm-header-4 {
+  font-family: var(--font-monospace) !important;
+  background-color: var(--pre-code) !important;
+  font-weight: inherit !important;
+}
+
+.cm-s-obsidian
+  span.cm-inline-code.cm-header-5:not(.cm-formatting):not(.cm-hmd-indented-code):not(.obsidian-search-match-highlight),
+.cm-s-obsidian span.cm-inline-code.cm-header-5 {
+  font-family: var(--font-monospace) !important;
+  background-color: var(--pre-code) !important;
+  font-weight: inherit !important;
+}
+
+.cm-s-obsidian
+  span.cm-inline-code.cm-header-6:not(.cm-formatting):not(.cm-hmd-indented-code):not(.obsidian-search-match-highlight),
+.cm-s-obsidian span.cm-inline-code.cm-header-6 {
+  font-family: var(--font-monospace) !important;
+  background-color: var(--pre-code) !important;
+  font-weight: inherit !important;
+}
+
+.cm-s-obsidian span.cm-inline-code {
+  padding-bottom: 0;
+}
+
+/*internal links*/
+a,
+a.internal-link,
+span.cm-hmd-internal-link,
+.cm-link.cm-header.cm-header-1,
+.cm-link.cm-header.cm-header-2,
+.cm-link.cm-header.cm-header-3,
+.cm-link.cm-header.cm-header-4,
+.cm-link.cm-header.cm-header-5,
+.cm-link.cm-header.cm-header-6,
+.cm-link.cm-header.cm-hmd-barelink,
+.cm-s-obsidian .cm-header.cm-hmd-internal-link,
+.cm-s-obsidian .cm-header span.cm-hmd-internal-link {
+  transition-duration: ease 500ms;
+  color: var(--text-accent);
+  text-decoration: none;
+}
+
+.cm-s-obsidian span.cm-url:hover {
+  color: var(--text-muted);
+}
+
+.cm-s-obsidian span.cm-url.cm-string:not(.cm-hmd-footnote-url) {
+  color: var(--text-faint);
+}
+
+a:hover,
+.external-link:hover,
+.cm-hmd-internal-link:hover {
+  color: var(--text-accent);
+  text-decoration-line: unset; /* remove the underline of external link when hover */
+}
+
+/* remove the underline of external link */
+.external-link{
+  text-decoration-line: unset;
+  /*var(--link-external-decoration);*/
+}
+
+/* LINKS IN PREVIEW*/
+
+.markdown-preview-view .internal-link {
+  text-decoration: none;
+}
+
+.markdown-preview-view .internal-link:hover {
+  text-decoration-line: unset; /* remove the underline of internal link when hover */
+}
+
+.markdown-preview-view .internal-link.is-unresolved {
+  opacity: 0.7;
+}
+
+/*MARKINGS*/
+.cm-s-obsidian .cm-header.cm-hashtag,
+.cm-s-obsidian span.cm-hashtag {
+  color: var(--text-muted);
+}
+
+.cm-s-obsidian span.cm-formatting-link,
+.cm-s-obsidian .cm-header.cm-formatting-link,
+.cm-s-obsidian span.cm-formatting-image.cm-link,
+.cm-s-obsidian span.cm-formatting-link-string.cm-url.cm-string {
+  color: var(--text-faint);
+  display: inline-block;
+}
+
+.markdown-preview-view hr {
+  border: none;
+  border-top: 1px solid;
+  border-color: var(--background-modifier-border);
+}
+
+/* SIDE NOTES (ASIDE)*/
+
+aside:before {
+  content: "";
+  font-size: 2.5em;
+  line-height: 0.1em;
+  vertical-align: -0.2em;
+}
+
+aside {
+  float: right;
+  max-width: 45%;
+  padding: 1.25em;
+  margin-left: 20px;
+  margin-bottom: 0.75em;
+  position: relative;
+  color: var(--text-normal);
+  line-height: var(--editor-line-height);
+  border: 1px solid var(--background-modifier-border) !important;
+  box-shadow: 8px 8px var(--background-modifier-border);
+}
+
+.right-side {
+  float: left;
+  margin-right: 20px;
+  margin-left: unset;
+  margin-bottom: 0.75em;
+  box-shadow: -8px 8px var(--background-modifier-border) !important;
+}
+
+aside > p {
+  margin: 0.5rem;
+}
+
+/*SUBSCRIPT & SUPERSCRIPT*/
+
+.markdown-preview-view sub,
+.markdown-preview-view sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+.markdown-preview-view sup {
+  top: -0.5em;
+}
+
+.markdown-preview-view sub {
+  bottom: -0.25em;
+}
+
+/* TEXT MARKINGS*/
+
+/*STRIKETHROUGH*/
+del,
+.cm-strikethrough {
+  text-decoration-color: var(--text-muted);
+  text-decoration-thickness: 2px !important;
+}
+
+/* ITALICS */
+em,
+.cm-s-obsidian .cm-em.cm-header,
+.cm-s-obsidian .cm-em.cm-header.cm-header-1,
+.cm-s-obsidian .cm-em.cm-header.cm-header-2,
+.cm-s-obsidian .cm-em.cm-header.cm-header-3,
+.cm-s-obsidian .cm-em.cm-header.cm-header-4,
+.cm-s-obsidian .cm-em.cm-header.cm-header-5,
+.cm-s-obsidian .cm-em.cm-header.cm-header-6,
+.rainbow-headers .cm-s-obsidian .cm-em.cm-header.cm-header-1,
+.rainbow-headers .cm-s-obsidian .cm-em.cm-header.cm-header-2,
+.rainbow-headers .cm-s-obsidian .cm-em.cm-header.cm-header-3,
+.rainbow-headers .cm-s-obsidian .cm-em.cm-header.cm-header-4,
+.rainbow-headers .cm-s-obsidian .cm-em.cm-header.cm-header-5,
+.rainbow-headers .cm-s-obsidian .cm-em.cm-header.cm-header-6,
+.markdown-preview-section em,
+.cm-s-obsidian .cm-em {
+  font-style: italic;
+  color: var(--em-color);
+}
+
+/* BOLD */
+
+strong,
+.cm-s-obsidian .cm-strong.cm-header,
+.cm-s-obsidian .cm-strong.cm-header.cm-header-1,
+.cm-s-obsidian .cm-strong.cm-header.cm-header-2,
+.cm-s-obsidian .cm-strong.cm-header.cm-header-3,
+.cm-s-obsidian .cm-strong.cm-header.cm-header-4,
+.cm-s-obsidian .cm-strong.cm-header.cm-header-5,
+.cm-s-obsidian .cm-strong.cm-header.cm-header-6,
+.rainbow-headers .cm-s-obsidian .cm-strong.cm-header.cm-header-1,
+.rainbow-headers .cm-s-obsidian .cm-strong.cm-header.cm-header-2,
+.rainbow-headers .cm-s-obsidian .cm-strong.cm-header.cm-header-3,
+.rainbow-headers .cm-s-obsidian .cm-strong.cm-header.cm-header-4,
+.rainbow-headers .cm-s-obsidian .cm-strong.cm-header.cm-header-5,
+.rainbow-headers .cm-s-obsidian .cm-strong.cm-header.cm-header-6,
+.cm-header.cm-header-3.cm-hmd-internal-link,
+.markdown-preview-section strong,
+.cm-s-obsidian .cm-strong {
+  font-weight: var(--strong-weight);
+  color: var(--strong-color);
+}
+
+/*STRIKETHROUGH*/
+
+.cm-s-obsidian span.cm-link.cm-strikethrough,
+.cm-s-obsidian span.cm-hmd-internal-link.cm-strikethrough {
+  text-decoration: line-through;
+  text-decoration-color: var(--text-muted);
+  text-decoration-thickness: 3px;
+}
+
+.cm-strikethrough {
+  text-decoration-color: var(--text-muted);
+  text-decoration-thickness: 3px;
+}
+
+/* BLOCKQUOTES */
+
+.markdown-preview-view blockquote:before {
+  content: "❝"; /*\edd5 \ec51*/
+  font-family: Karmilla;
+  font-weight: 900;
+  font-size: 2.5em;
+  margin-right: 0.05em;
+  line-height: 0.1em;
+  vertical-align: -0.3em;
+}
+
+.naked-bq .markdown-preview-view blockquote:before {
+  content: "";
+  margin-right: 0em;
+}
+
+blockquote p {
+  color: hsl(var(--blockquote-border));
+}
+
+blockquote p:first-child {
+  display: inline;
+}
+
+.markdown-preview-view blockquote {
+  line-height: var(--editor-line-height);
+  color: hsl(var(--blockquote-border));
+  font-family: var(--default-font);
+  border: none;
+  border-left: 0.3rem solid hsl(var(--blockquote-border));
+  background-color: var(--blockquote-bg);
+  border-radius: 0px;
+  margin: 1rem 0rem 1rem 0rem;
+  padding: 2rem;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+}
+
+kbd {
+  line-height: 1.476;
+  font-weight: 700;
+  padding: 4px 6px;
+  font-size: 0.875em;
+  border-radius: 4px;
+  white-space: nowrap;
+  display: inline-block;
+  color: var(--text-normal);
+  font-family: var(--font-monospace);
+  background-color: var(--background-secondary-alt);
+  border: 1px solid var(--background-modifier-border);
+  box-shadow: 0 1.5px 1px rgba(0, 0, 0, 0.2),
+    0 2px 0 0 rgba(255, 255, 255, 0.25) inset;
+}
+
+/*----------------------------------------------------------------
+CODEBLOCKS & INLINE CODE
+----------------------------------------------------------------*/
+
+.cm-s-obsidian pre.HyperMD-codeblock-begin {
+  padding-top: 0.75rem;
+}
+
+/* Code block border color */
+.cm-s-obsidian div.HyperMD-codeblock-begin-bg {
+  padding-top: 0.5rem;
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
+}
+
+/* Code block border color */
+.cm-s-obsidian div.HyperMD-codeblock-end-bg {
+  border-bottom-left-radius: 6px;
+  border-bottom-right-radius: 6px;
+}
+
+.no-show-code-block-border .cm-s-obsidian div.HyperMD-codeblock-begin-bg,
+.no-show-code-block-border .cm-s-obsidian div.HyperMD-codeblock-end-bg,
+.no-show-code-block-border .cm-s-obsidian div.HyperMD-codeblock-bg {
+  border: none;
+}
+
+body:not(.no-show-code-block-border)
+  .cm-s-obsidian
+  div.HyperMD-codeblock-begin-bg {
+  border-top: 1px solid var(--code-block-border);
+}
+
+body:not(.no-show-code-block-border)
+  .cm-s-obsidian
+  div.HyperMD-codeblock-end-bg {
+  border-bottom: 1px solid var(--code-block-border);
+}
+
+/* Code block left and right border colors */
+body:not(.no-show-code-block-border) .cm-s-obsidian div.HyperMD-codeblock-bg {
+  border-left: 1px solid var(--code-block-border);
+  border-right: 1px solid var(--code-block-border);
+}
+
+/*Copy button*/
+button.copy-code-button {
+  color: var(--text-normal) !important;
+  font-family: var(--font-monospace) !important;
+  background-color: var(--background-modifier-border) !important;
+  border-radius: 0px 6px 0px 0px !important;
+  transition: 100ms;
+  text-transform: lowercase !important;
+  font-weight: 500 !important;
+  padding: 3px 12px !important;
+  font-size: 0.8em;
+  box-shadow: none;
+  position: absolute;
+  top: -5px;
+  right: -5px;
+}
+
+.copy-code-button:hover {
+  background-color: var(--background-secondary) !important;
+}
+
+body:not(.no-show-code-block-border) .copy-code-button {
+  border: 1px solid var(--code-block-border) !important;
+  margin-top: -1px !important;
+  margin-right: -1px !important;
+}
+
+/*----------------------------------------------------------------
+EDITOR SECTION
+----------------------------------------------------------------*/
+
+.theme-dark pre[class*="language-"],
+.theme-light pre[class*="language-"] {
+  text-shadow: none;
+  background-color: var(--pre-code);
+  background: var(--pre-code);
+  margin: 1.25em 0em;
+}
+
+.markdown-preview-view pre,
+.markdown-preview-view code,
+.cm-inline-code,
+.cm-s-obsidian span.cm-inline-code,
+.HyperMD-codeblock,
+.cm-s-obsidian .HyperMD-codeblock-bg,
+.cm-s-obsidian
+  span.cm-inline-code:not(.cm-formatting):not(.cm-hmd-indented-code):not(.obsidian-search-match-highlight) {
+  --background-primary-alt: var(--pre-code);
+}
+
+.theme-dark code[class*="language-"],
+.theme-light code[class*="language-"] {
+  text-shadow: none;
+}
+
+.cm-inline-code,
+.cm-s-obsidian span.cm-inline-code {
+  color: var(--text-muted);
+  font-size: var(--code-font-size);
+  font-family: var(--font-monospace);
+  padding: 1px;
+}
+
+.cm-hmd-codeblock {
+  font-size: var(--code-font-size);
+}
+
+.cm-s-obsidian .HyperMD-codeblock {
+  font-size: unset;
+}
+
+.cm-s-obsidian .HyperMD-codeblock {
+  line-height: var(--code-line-height);
+}
+
+.HyperMD-codeblock,
+.cm-s-obsidian .HyperMD-codeblock {
+  font-family: var(--font-monospace);
+  line-height: var(--code-line-height);
+  color: var(--text-muted);
+}
+
+.HyperMD-codeblock-begin {
+  border-style: none;
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
+}
+
+.HyperMD-codeblock-end {
+  border-style: none;
+  border-bottom-left-radius: 6px;
+  border-bottom-right-radius: 6px;
+}
+
+.cm-s-obsidian span.cm-operator,
+.cm-s-obsidian span.cm-property:not(.cm-s-obsidian span.cm-formatting-task),
+.cm-s-obsidian span.cm-variable {
+  /* color: #e3e7;*/
+}
+
+.theme-dark .cm-s-obsidian span.cm-operator,
+.theme-dark
+  .cm-s-obsidian
+  span.cm-property:not(.cm-s-obsidian span.cm-formatting-task),
+.theme-dark .cm-s-obsidian span.cm-variable {
+  color: #36e622;
+}
+
+/*----------------------------------------------------------------
+PREVIEW SECTION
+----------------------------------------------------------------*/
+.theme-dark code[class*="language-"],
+.theme-dark pre[class*="language-"],
+.theme-light code[class*="language-"],
+.theme-light pre[class*="language-"] {
+  white-space: pre-wrap;
+  word-spacing: normal;
+  word-break: normal;
+  word-wrap: normal;
+  tab-size: 4;
+  hyphens: none;
+}
+
+body:not(.no-show-lang) pre[class*="language-"]::after {
+  content: attr(class);
+  transition: 200ms;
+  animation: pop-pop 250ms ease-in-out;
+  font-size: 0.8em;
+  font-family: var(--monospace-font);
+  color: var(--text-muted);
+  position: absolute;
+  right: 10px;
+  bottom: 7px;
+}
+
+body:not(.no-show-lang).is-mobile pre[class*="language-"]::after {
+  content: attr(class);
+  transition: 200ms;
+  animation: pop-pop 250ms ease-in-out;
+  font-size: 0.65em;
+  font-family: var(--monospace-font);
+  color: var(--text-muted);
+  position: absolute;
+  right: 34px;
+  bottom: -5px;
+}
+
+code.yellow {
+  color: var(--text-normal);
+  background-color: var(--yellow-highlighter);
+}
+code.pink {
+  color: var(--text-normal);
+  background-color: var(--pink-highlighter);
+}
+code.blue {
+  color: var(--text-normal);
+  background-color: var(--blue-highlighter);
+}
+code.green {
+  color: var(--text-normal);
+  background-color: var(--green-highlighter);
+}
+code.red {
+  color: var(--text-normal);
+  background-color: var(--red-highlighter);
+}
+code.grey {
+  color: var(--text-normal);
+  background-color: var(--grey-highlighter);
+}
+code.gray {
+  color: var(--text-normal);
+  background-color: var(--grey-highlighter);
+}
+code.orange {
+  color: var(--text-normal);
+  background-color: var(--orange-highlighter);
+}
+code.red {
+  color: var(--text-normal);
+  background-color: var(--red-highlighter);
+}
+code.purple {
+  color: var(--text-normal);
+  background-color: var(--purple-highlighter);
+}
+code.yellow-green {
+  color: var(--text-normal);
+  background-color: #e5ffb780;
+}
+
+@media print {
+  code.yellow {
+    background-color: var(--yellow-highlighter);
+  }
+  code.pink {
+    background-color: var(--pink-highlighter);
+  }
+  code.blue {
+    background-color: var(--blue-highlighter);
+  }
+  code.green {
+    background-color: var(--green-highlighter);
+  }
+  code.red {
+    background-color: var(--red-highlighter);
+  }
+  code.grey {
+    background-color: var(--grey-highlighter);
+  }
+  code.gray {
+    background-color: var(--grey-highlighter);
+  }
+  code.orange {
+    background-color: var(--orange-highlighter);
+  }
+  code.red {
+    background-color: var(--red-highlighter);
+  }
+  code.purple {
+    background-color: var(--purple-highlighter);
+  }
+  code.yellow-green {
+    color: var(--text-normal);
+    background-color: #e5ffb780;
+  }
+}
+
+body:not(.no-show-lang) pre[class~="language-admonition"]:after,
+body:not(.no-show-lang).is-mobile pre[class~="language-admonition"]:after {
+  content: "ad";
+}
+body:not(.no-show-lang) pre[class~="language-c"]:after,
+body:not(.no-show-lang).is-mobile pre[class~="language-c"]:after {
+  content: "c";
+}
+body:not(.no-show-lang) pre[class~="language-python"]:after,
+body:not(.no-show-lang).is-mobile pre[class~="language-python"]:after {
+  content: "py";
+}
+body:not(.no-show-lang) pre[class~="language-nginx"]:after,
+body:not(.no-show-lang).is-mobile pre[class~="language-nginx"]:after {
+  content: "nginx";
+}
+body:not(.no-show-lang) pre[class~="language-css"]:after,
+body:not(.no-show-lang).is-mobile pre[class~="language-css"]:after {
+  content: "css";
+}
+body:not(.no-show-lang) pre[class~="language-svg"]:after,
+body:not(.no-show-lang).is-mobile pre[class~="language-svg"]:after {
+  content: "svg";
+}
+body:not(.no-show-lang) pre[class~="language-node"]:after,
+body:not(.no-show-lang).is-mobile pre[class~="language-node"]:after {
+  content: "node";
+}
+body:not(.no-show-lang) pre[class~="language-react"]:after,
+body:not(.no-show-lang).is-mobile pre[class~="language-react"]:after {
+  content: "jsx";
+}
+body:not(.no-show-lang) pre[class~="language-javascript"]:after,
+body:not(.no-show-lang) pre[class~="language-js"]:after,
+body:not(.no-show-lang).is-mobile pre[class~="language-javascript"]:after,
+body:not(.no-show-lang).is-mobile pre[class~="language-js"]:after {
+  content: "js";
+}
+body:not(.no-show-lang) pre[class~="language-php"]:after,
+body:not(.no-show-lang).is-mobile pre[class~="language-php"]:after {
+  content: "php";
+}
+body:not(.no-show-lang) pre[class~="language-shell"]:after,
+body:not(.no-show-lang).is-mobile pre[class~="language-shell"]:after {
+  content: "sh";
+}
+body:not(.no-show-lang) pre[class~="language-bash"]:after,
+body:not(.no-show-lang).is-mobile pre[class~="language-bash"]:after {
+  content: "sh";
+}
+body:not(.no-show-lang) pre[class~="language-typescript"]:after,
+body:not(.no-show-lang).is-mobile pre[class~="language-typescript"]:after {
+  content: "ts";
+}
+body:not(.no-show-lang) pre[class~="language-shell"]:after,
+body:not(.no-show-lang).is-mobile pre[class~="language-shell"]:after {
+  content: "sh";
+}
+body:not(.no-show-lang) pre[class~="language-flow"]:after,
+body:not(.no-show-lang).is-mobile pre[class~="language-flow"]:after {
+  content: "flow";
+}
+body:not(.no-show-lang) pre[class~="language-sequence"]:after,
+body:not(.no-show-lang).is-mobile pre[class~="language-sequence"]:after {
+  content: "seq";
+}
+body:not(.no-show-lang) pre[class~="language-sql"]:after,
+body:not(.no-show-lang).is-mobile pre[class~="language-sql"]:after {
+  content: "sql";
+}
+body:not(.no-show-lang) pre[class~="language-yaml"]:after,
+body:not(.no-show-lang).is-mobile pre[class~="language-yaml"]:after {
+  content: "yml";
+}
+body:not(.no-show-lang) pre[class~="language-ini"]:after,
+body:not(.no-show-lang).is-mobile pre[class~="language-ini"]:after {
+  content: "ini";
+}
+body:not(.no-show-lang) pre[class~="language-xml"]:after,
+body:not(.no-show-lang).is-mobile pre[class~="language-xml"]:after {
+  content: "xml";
+}
+body:not(.no-show-lang) pre[class~="language-git"]:after,
+body:not(.no-show-lang).is-mobile pre[class~="language-git"]:after {
+  content: "git";
+}
+body:not(.no-show-lang) pre[class~="language-cs"]:after,
+body:not(.no-show-lang).is-mobile pre[class~="language-cs"]:after {
+  content: "cs";
+}
+body:not(.no-show-lang) pre[class~="language-cpp"]:after,
+body:not(.no-show-lang).is-mobile pre[class~="language-cpp"]:after {
+  content: "cpp";
+}
+body:not(.no-show-lang) pre[class~="language-java"]:after,
+body:not(.no-show-lang).is-mobile pre[class~="language-java"]:after {
+  content: "java";
+}
+body:not(.no-show-lang) pre[class~="language-json"]:after,
+body:not(.no-show-lang).is-mobile pre[class~="language-json"]:after {
+  content: "json";
+}
+body:not(.no-show-lang) pre[class~="language-html"]:after,
+body:not(.no-show-lang).is-mobile pre[class~="language-html"]:after {
+  content: "html";
+}
+body:not(.no-show-lang) pre[class~="language-text"]:after,
+body:not(.no-show-lang) pre[class~="language-txt"]:after,
+body:not(.no-show-lang).is-mobile pre[class~="language-text"]:after,
+body:not(.no-show-lang).is-mobile pre[class~="language-txt"]:after {
+  content: "txt";
+}
+
+.markdown-preview-section pre {
+  padding: 1em;
+  border-radius: 6px;
+  font-family: var(--font-monospace);
+}
+
+body:not(.no-show-code-block-border) .markdown-preview-section pre {
+  border: 1px solid var(--code-block-border);
+}
+
+.markdown-preview-section pre code,
+.markdown-preview-section code {
+  font-family: var(--font-monospace);
+  font-size: var(--code-font-size);
+}
+
+.markdown-preview-section pre code {
+  max-height: 400px;
+  line-height: 1.5em;
+  color: var(--text-muted);
+}
+
+.markdown-preview-section code {
+  font-weight: inherit;
+  display: inline;
+  color: var(--text-muted);
+}
+
+/*----------------------------------------------------------------
+HIGHLIGHTING (MARK)
+----------------------------------------------------------------*/
+
+mark > strong {
+  color: var(--text-highlight-color) !important;
+  font-weight: 900;
+}
+
+mark > em {
+  color: var(--text-highlight-color) !important;
+  font-weight: inherit;
+}
+
+.markdown-preview-view mark {
+  color: var(--text-highlight-color) !important;
+  font-weight: inherit;
+  background-color: var(--text-highlight-rgb);
+}
+
+.cm-s-obsidian span.cm-highlight {
+  color: var(--text-highlight-color);
+  font-weight: inherit;
+  background-color: var(--text-highlight-rgb);
+}
+
+/*----------------------------------------------------------------
+REALISTIC HIGHLIGHT
+----------------------------------------------------------------*/
+
+mark.yellow {
+  --text-highlight-rgb: var(--yellow-highlighter);
+}
+mark.pink {
+  --text-highlight-rgb: var(--pink-highlighter);
+}
+mark.blue {
+  --text-highlight-rgb: var(--blue-highlighter);
+}
+mark.green {
+  --text-highlight-rgb: var(--green-highlighter);
+}
+mark.red {
+  --text-highlight-rgb: var(--red-highlighter);
+}
+mark.grey {
+  --text-highlight-rgb: var(--grey-highlighter);
+}
+mark.gray {
+  --text-highlight-rgb: var(--grey-highlighter);
+}
+mark.orange {
+  --text-highlight-rgb: var(--orange-highlighter);
+}
+mark.red {
+  --text-highlight-rgb: var(--red-highlighter);
+}
+mark.purple {
+  --text-highlight-rgb: var(--purple-highlighter);
+}
+
+.markdown-preview-view mark {
+  margin: 0 -0.05em;
+  padding: 0.125em 0.15em;
+  border-radius: 0.2em;
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
+}
+
+span.cm-highlight {
+  padding: 0.1em 0;
+  border-radius: 0.2em;
+  background: var(--text-highlight-rgb);
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
+}
+
+span.cm-formatting-highlight {
+  /*margin: 0 0 0 -0.4em;*/
+  padding-left: 0.15em;
+  padding-right: 0em;
+  background: var(--text-highlight-rgb);
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
+}
+
+.cm-highlight + span.cm-formatting-highlight {
+  padding-left: 0em;
+  padding-right: 0.15em;
+  background: var(--text-highlight-rgb);
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
+}
+
+/*----------------------------------------------------------------
+VIEW ACTIONS
+----------------------------------------------------------------*/
+
+.workspace > .mod-root .mod-active .view-actions a {
+  color: var(--text-normal) !important;
+}
+
+.view-actions a {
+  color: var(--text-muted) !important;
+}
+
+.workspace > .mod-root .mod-active .view-actions a:hover {
+  color: var(--interactive-accent) !important;
+}
+
+.view-actions a:hover {
+  color: var(--interactive-accent) !important;
+}
+
+/*----------------------------------------------------------------
+TABLE ELEMENTS
+----------------------------------------------------------------*/
+
+/*NUMBER TABLES*/
+
+.numbertable table {
+  counter-reset: section;
+}
+
+.numbertable table > tbody > tr > td:first-child::before {
+  counter-increment: section;
+  content: counter(section) ". ";
+}
+
+/*COLOR ROWS*/
+
+.color-rows tr:nth-child(even) {
+  background: var(--background-primary);
+}
+.color-rows tr:nth-child(odd) {
+  background: var(--background-secondary);
+}
+
+/*COLOR COLUMNS*/
+
+.cm-s-obsidian .HyperMD-table-row.HyperMD-table-row-0 {
+  font-weight: 600;
+}
+
+.HyperMD-table-row,
+.cm-s-obsidian .HyperMD-table-row {
+  white-space: pre;
+  word-break: normal;
+  overflow-wrap: normal;
+}
+
+/* preview */
+.markdown-preview-view table {
+  width: 100%;
+  border: 1px solid var(--background-modifier-border);
+  border-spacing: 0;
+  overflow: hidden;
+}
+
+.markdown-preview-view th,
+.markdown-preview-view td {
+  padding: 5px 10px;
+  vertical-align: top;
+  border-color: var(--background-modifier-border);
+}
+
+.markdown-preview-view th:first-child,
+.markdown-preview-view td:first-child {
+  padding-left: 15px;
+}
+
+.markdown-preview-view th {
+  background-color: var(--background-primary-alt);
+  border-bottom: none;
+  font-weight: 500;
+  font-size: var(--large-font-size) !important;
+}
+
+.markdown-preview-view tr + tr td {
+  border-top: none;
+}
+
+.table-view-table > thead > tr > th {
+  text-transform: none !important;
+  font-weight: 700;
+  font-size: larger;
+}
+
+th {
+  font-weight: 600 !important;
+}
+
+table {
+  border-collapse: collapse;
+}
+
+/* FOOTNOTES */
+
+.footnotes {
+  font-size: 1em !important;
+}
+
+.cm-s-obsidian span.cm-footref {
+  font-size: 1em !important;
+}
+
+.cm-s-obsidian pre.HyperMD-footnote {
+  font-size: 1em !important;
+}
+
+.footnote-backref.footnote-link {
+  font-family: var(--default-font);
+  font-size: 0.75em;
+}
+
+.footnote-link {
+  color: var(--text-muted);
+  text-decoration: none;
+}
+
+.footnote-link:hover {
+  color: var(--text-accent);
+  text-decoration: none;
+}
+
+.footnote-backref {
+  color: var(--text-muted);
+  margin-left: 0.2rem;
+  color: var(--interactive-accent-hover);
+  text-decoration: none;
+}
+
+.footnote-backref:hover {
+  color: var(--interactive-accent-hover);
+}
+
+.footnotes li::marker {
+  color: var(--text-muted);
+}
+
+.footnote-ref {
+  font-size: 1rem;
+  text-decoration: none;
+}
+
+.cm-s-obsidian span.cm-footref,
+.cm-s-obsidian span.cm-blockid {
+  display: inline-block;
+  font-size: 0.875em;
+  vertical-align: unset;
+  color: var(--text-muted);
+  margin-top: -0.2em;
+}
+
+/*SEARCH QUERY*/
+body:not(.is-mobile) .tree-item-self,
+.search-result-file-title {
+  line-height: 1.2em;
+}
+
+body:not(.no-svg-replace)
+  .markdown-preview-view
+  .internal-query.is-embed
+  .internal-query-header-icon
+  > svg {
+  background-color: var(--text-muted);
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M57.113 9.554C56.333 8.771 55.275 8.333 54.167 8.333H25C20.404 8.333 16.667 12.071 16.667 16.667v66.667c0 4.596 3.738 8.333 8.333 8.333h50c4.596 0 8.333 -3.738 8.333 -8.333V37.5c0 -1.108 -0.438 -2.167 -1.221 -2.946L57.113 9.554zM25 16.667h27.442L75 39.225l0.008 38.225l-10.7 -10.7C65.767 64.271 66.667 61.413 66.667 58.333c0 -9.192 -7.475 -16.667 -16.667 -16.667s-16.667 7.475 -16.667 16.667s7.475 16.667 16.667 16.667c3.079 0 5.938 -0.9 8.417 -2.358L69.108 83.333H25V16.667zM50 66.667c-4.596 0 -8.333 -3.738 -8.333 -8.333s3.738 -8.333 8.333 -8.333s8.333 3.738 8.333 8.333S54.596 66.667 50 66.667z"></path></svg>');
+}
+
+.markdown-preview-view .internal-query.is-embed .internal-query-header-title {
+  font-weight: 500;
+}
+
+.markdown-preview-view .internal-query.is-embed {
+  border: 1px solid var(--background-modifier-border);
+  background: var(--background-secondary);
+  border-radius: 6px;
+  padding: 10px;
+}
+
+.search-result-file-matched-text {
+  padding-left: 2px;
+  padding-right: 2px;
+  border-radius: 3px;
+  background: hsla(var(--accent-hsl), 0.25);
+}
+
+.tree-item-self {
+  border-radius: 6px;
+}
+
+.tree-item-flair {
+  border: 1px solid transparent;
+  padding: 0px;
+  padding-left: 3px;
+  padding-right: 3px;
+  background-color: var(--background-zero);
+}
+
+.internal-query .internal-query-header {
+  margin-top: 5px;
+}
+
+.internal-query.is-embed .search-result-file-match {
+  width: 98%;
+}
+
+.tree-item-self:hover {
+  color: var(--text-muted) !important;
+}
+
+.tree-item-self.is-clickable:hover {
+  background-color: unset;
+}
+
+.tree-item-self:hover .tree-item-flair {
+  background-color: var(--background-zero);
+}
+
+/*----------------------------------------------------------------
+Search Pane
+----------------------------------------------------------------*/
+
+.suggestion-container.mod-search-suggestion {
+  max-width: auto !important;
+  padding: 5px 5px 10px 5px !important;
+}
+
+.search-result-file-title {
+  vertical-align: middle;
+  padding-left: 25px; /*findme*/
+  padding-right: 7px;
+  font-weight: 500;
+  line-height: 1em;
+  /*padding: 0px 5px 0px 25px; findme*/
+}
+
+.search-result-file-match:hover {
+  background: inherit;
+  transition: 200ms;
+}
+
+.search-result-file-title:hover {
+  background: inherit !important;
+  transition: 200ms;
+}
+
+.search-result-file-title {
+  font-style: none;
+  line-height: 1em;
+  font-weight: 500; /*i don't want it bolded*/
+}
+
+.search-result-file-matches {
+  margin: 0;
+  padding: 0 0 0 5px !important;
+  border-bottom: none;
+}
+
+.search-result-file-match {
+  margin-top: 0;
+  cursor: pointer !important;
+  position: relative;
+  padding: 8px 10px 8px 10px;
+  margin-bottom: 5px;
+  width: 96%;
+  transition: 100ms;
+}
+
+.search-result-file-match:after {
+  display: none;
+}
+
+.search-result-file-match:last-child {
+  margin-bottom: 1rem;
+}
+
+.search-result-file-match:before {
+  content: none;
+}
+
+.search-result-file-match:not(.search-info-more-matches) {
+  transition: 500ms;
+  margin-top: 10px;
+  border: 1px solid var(--background-modifier-border);
+  background: var(--background-zero);
+  border-radius: 5px;
+  transition: 100ms;
+}
+
+.search-result-file-match:not(.search-info-more-matches):hover {
+  border: 1px solid var(--interactive-accent);
+}
+
+/*----------------------------------------------------------------
+BUTTONS
+----------------------------------------------------------------*/
+
+label {
+  font-family: var(--default-font) !important;
+}
+
+button {
+  padding: 0.6em 1em 0.6em 1em;
+  font-family: var(--default-font) !important;
+  text-transform: capitalize !important;
+  line-height: 1.3em;
+  font-size: 0.875em !important;
+  box-shadow: 0px 1px 8px rgb(10 15 73 / 1%),
+    inset 0 -1px 1px rgb(10 15 73 / 5%);
+}
+
+.theme-light .menu button,
+.theme-light .modal button {
+  box-shadow: 0px 1px 8px rgb(10 15 73 / 1%),
+    inset 0 -1px 1px rgb(10 15 73 / 5%);
+}
+
+.theme-dark .menu button,
+.theme-dark .modal button {
+  box-shadow: 0px 1px 8px rgb(10 15 73 / 1%),
+    inset 0 -1px 2px var(--background-modifier-border);
+}
+
+.theme-light .modal.mod-settings button:not(.mod-cta):not(.mod-warning),
+.setting-item-control button,
+.modal button,
+.modal button.mod-cta {
+  border: 1px solid var(--background-modifier-border);
+}
+
+.theme-dark .modal.mod-settings button:not(.mod-cta):not(.mod-warning),
+.setting-item-control button,
+.modal button,
+.modal button.mod-cta {
+  border: 1px solid var(--background-modifier-border);
+}
+
+button.mod-cta {
+  line-height: 1.25em;
+  font-size: 0.875em !important;
+  padding: 0.6em 1em 0.6em 1em;
+}
+
+.modal.mod-settings button:not(.mod-cta):not(.mod-warning),
+.setting-item-control button,
+.modal button,
+.modal button.mod-cta {
+  border: 1px solid var(--background-modifier-border);
+}
+
+button#send-button,
+.graph-color-button-container button,
+.graph-color-button-container button:hover,
+.modal.mod-settings button:not(.mod-cta):not(.mod-warning),
+.setting-item-control button,
+.modal button.mod-cta,
+.modal button:not(.mod-cta):not(.mod-warning),
+.modal button:not(.mod-cta):not(.mod-warning).list-item-part {
+  background-color: var(--mod-button);
+  color: var(--text-normal);
+}
+
+.theme-dark button#send-button,
+.theme-dark .graph-color-button-container button:hover,
+.theme-dark .graph-color-button-container button,
+.theme-dark .modal.mod-settings button:not(.mod-cta):not(.mod-warning),
+.theme-dark .setting-item-control button,
+.theme-dark
+  .modal
+  button.mod-cta
+  .theme-dark
+  .modal
+  button:not(.mod-cta):not(.mod-warning),
+.theme-dark .modal button:not(.mod-cta):not(.mod-warning).list-item-part {
+  background-color: var(--mod-button);
+}
+
+button#send-button:active,
+.theme-dark button#send-button:active,
+.theme-dark
+  .modal.mod-settings
+  button:not(.mod-cta):not(.mod-warning):active
+  .theme-dark
+  .setting-item-control
+  button:active,
+.theme-dark .modal button:active,
+.theme-dark .modal button.mod-cta:active,
+.modal.mod-settings button:not(.mod-cta):not(.mod-warning):active,
+.setting-item-control button:active,
+.modal button:active,
+.modal button.mod-cta:active {
+  color: var(--text-on-accent);
+  background: var(--interactive-accent-hover);
+}
+
+button.mod-cta a:hover {
+  text-decoration: none !important;
+  color: inherit;
+}
+
+/*----------------------------------------------------------------
+MODALS
+----------------------------------------------------------------*/
+
+.modal-container input[type="text"] {
+  min-height: 2.5em;
+}
+
+.modal.mod-sync-history {
+  background-color: var(--background-secondary-alt) !important;
+  border: 1px solid var(--background-modifier-border);
+}
+
+.modal-content {
+  margin-bottom: 0px !important;
+  padding-right: 0;
+}
+
+.modal {
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 6px;
+  max-width: 960px;
+  max-height: 86vh;
+  overflow: hidden;
+}
+
+/*----------------------------------------------------------------
+SETTINGS MODAL
+----------------------------------------------------------------*/
+.setting-item-control textarea,
+.hotkey-search-container input,
+.setting-item-control input {
+  font-size: 0.875em;
+  /*
+padding: 1.2em 1em 1.2em 1em;*/
+}
+
+.setting-item-name {
+  font-weight: 500;
+  color: var(--text-normal);
+}
+
+.modal-container p {
+  line-height: var(--editor-line-height);
+}
+
+.modal-container button.mod-cta a {
+  padding-top: 8px;
+  padding-bottom: 8px;
+}
+
+.modal.mod-settings a > button {
+  margin-right: 8px;
+}
+
+.modal-container button.mod-cta a {
+  font-weight: 400;
+}
+
+.modal.mod-settings .vertical-tab-content-container {
+  border-left: 1px solid var(--background-modifier-border);
+  padding-bottom: 0;
+  padding-right: 0;
+}
+
+.modal.mod-community-theme,
+.modal.mod-community-plugin {
+  width: 86vw;
+}
+
+.modal.mod-settings {
+  max-width: 960px;
+  width: 86vw;
+  height: 86vh;
+}
+
+.modal.mod-settings .vertical-tab-header {
+  height: 86vh;
+}
+
+.modal.mod-settings .vertical-tab-content-container {
+  height: 86vh;
+}
+
+.vertical-tab-content-container,
+.horizontal-tab-content,
+.vertical-tab-content {
+  background: var(--background-primary);
+}
+
+.modal.mod-settings .vertical-tab-header {
+  background: var(--background-secondary-alt);
+  padding-top: 5px;
+}
+
+.hotkey-list-container,
+.hotkey-search-container {
+  padding-left: 4px;
+}
+
+.modal.mod-settings .vertical-tab-content-container .search-input-container {
+  flex-grow: 0;
+  width: auto;
+  margin: 0;
+  /*padding: 10px 10px;*/ /* aligned search icon in "search installed plugins" */
+}
+
+.modal.mod-settings
+  .vertical-tab-content-container
+  .search-input-container
+  .search-input-clear-button {
+  right: 14px;
+}
+
+.vertical-tab-nav-item:hover,
+.vertical-tab-nav-item.is-active {
+  transition: 0.1s ease-in-out;
+  background-color: var(--background-zero);
+}
+
+.vertical-tab-nav-item {
+  font-weight: 500;
+  transition: 0.3s ease-in-out;
+}
+
+.community-plugin-search {
+  background-color: var(--background-secondary-alt);
+}
+
+.community-plugin-details {
+  background-color: var(--background-primary);
+}
+
+.community-plugin-info .community-plugin-desc {
+  font-size: 15px;
+  line-height: 20px;
+  margin-top: 8px;
+}
+
+.community-plugin-item {
+  padding: 15px;
+  margin: 0;
+  transition: 0.3s ease-in-out;
+  border-top: 1px solid var(--background-modifier-border);
+}
+
+.community-plugin-item:hover {
+  background-color: var(--background-primary-alt);
+  transition: 0.3s ease-in-out;
+}
+
+.community-plugin-name .flair {
+  letter-spacing: 0;
+  font-weight: 500;
+  vertical-align: 0.2em;
+}
+
+.notice {
+  color: var(--text-on-accent);
+  background-color: var(--background-modifier-accent);
+  border-radius: 5px;
+}
+
+.theme-dark .notice {
+  background-color: var(--background-modifier-accent);
+}
+
+.u-pop {
+  color: var(--interactive-accent);
+  font-weight: 600;
+}
+
+.workspace-drop-overlay {
+  opacity: 1;
+  background-color: transparent;
+}
+
+.vertical-tab-header-group-items {
+  padding: 0 5px;
+}
+
+.vertical-tab-header-group-title {
+  color: var(--text-normal);
+  text-transform: capitalize;
+  font-size: 15px;
+  padding: 5px 15px 5px 15px;
+  margin-left: 4px;
+  font-weight: 700;
+}
+
+.vertical-tab-nav-item {
+  padding: 2px 8px;
+  margin-left: 6px;
+  margin-right: 6px;
+  color: var(--text-muted);
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  cursor: pointer;
+}
+
+/*----------------------------------------------------------------
+MENU 
+----------------------------------------------------------------*/
+
+.menu {
+  padding: 8px 16px;
+  background-color: var(--background-secondary);
+}
+
+.menu-item {
+  display: flex;
+  font-size: 15px;
+  line-height: 1;
+  border-radius: 5px;
+  padding: 5px 8px;
+  margin: 0 -8px;
+  align-items: center;
+}
+
+.menu-separator {
+  height: 0;
+  margin: 10px 0;
+  border-bottom: 1px solid var(--background-modifier-border);
+}
+
+/*----------------------------------------------------------------
+DRAG GHOST
+----------------------------------------------------------------*/
+
+.drag-ghost {
+  color: var(--text-muted);
+  opacity: 0.8;
+  font-size: var(--small-font-size) !important;
+  border-radius: 5px;
+}
+
+.drag-ghost .is-grabbing {
+  cursor: -moz-grabbing !important;
+  cursor: -webkit-grabbing !important;
+}
+
+.drag-ghost .is-active {
+  cursor: -moz-grabbing !important;
+  cursor: -webkit-grabbing !important;
+}
+
+.drag-ghost-action {
+  cursor: grabbing;
+}
+
+/*----------------------------------------------------------------
+HOTKEY SETTINGS
+----------------------------------------------------------------*/
+
+.setting-add-hotkey-button,
+.setting-restore-hotkey-button {
+  padding: 6px;
+  border-radius: 5px;
+  cursor: pointer;
+  height: 32px;
+}
+
+.setting-restore-hotkey-button svg,
+.setting-add-hotkey-button svg {
+  height: 19px;
+  width: 19px;
+  vertical-align: -0.25em;
+}
+
+.setting-hotkey {
+  background-color: var(--background-primary-alt);
+  padding: 3px 15px 3px 15px;
+}
+
+.setting-hotkey.mod-empty {
+  background: transparent;
+  padding-right: 15px;
+  padding-left: 15px;
+  border: 1px solid var(--background-primary-alt);
+}
+
+/*----------------------------------------------------------------
+SUGGESTIONS
+----------------------------------------------------------------*/
+
+.suggestion-container {
+  background-color: hsl(var(--base-h), var(--base-s), calc(var(--base-d) + 6%));
+}
+
+.theme-light .suggestion-container {
+  background-color: hsl(var(--base-h), var(--base-s), calc(var(--base-l) + 6%));
+}
+
+.suggestion-item,
+.suggestion-empty {
+  font-size: 100%;
+  text-align: left;
+  line-height: 1.4em;
+}
+
+.suggestion-highlight {
+  font-weight: 700;
+}
+
+.suggestion-item.is-selected,
+.menu-item:hover {
+  cursor: pointer;
+  border-radius: 5px;
+  color: var(--text-normal);
+}
+
+.suggestion-item.is-selected {
+  background-color: hsl(var(--accent-hsl), 0.5);
+}
+
+.menu-item.selected:not(.is-disabled):not(.is-label),
+.menu-item:hover {
+  background-color: var(--background-zero);
+}
+
+.suggestion-item,
+.suggestion-empty {
+  font-size: var(--font-normal);
+}
+
+.menu,
+.modal,
+.suggestion-container {
+  border: 1px solid var(--background-modifier-border);
+  box-shadow: 0px 3px 15px
+    hsla(var(--base-h), var(--base-s), calc(var(--base-l) - 50%), 0.15) !important;
+}
+
+.prompt {
+  border: 1px solid var(--background-modifier-border);
+  box-shadow: 0px 3px 15px
+    hsla(var(--base-h), var(--base-s), calc(var(--base-l) - 50%), 0.15) !important;
+  padding: 1px; /* solve focus prompt-input border break */
+}
+
+.modal,
+.prompt,
+.suggestion-container {
+  border-radius: 10px;
+}
+
+.menu,
+.suggestion-container {
+  border-radius: 7px;
+}
+
+.theme-light .menu,
+.theme-light .modal,
+.theme-light .prompt,
+.theme-light .suggestion-container {
+  box-shadow: 0px 3px 15px
+    hsla(var(--base-h), var(--base-s), calc(var(--base-d) + 25%), 0.15) !important;
+}
+
+.prompt-instructions {
+  color: var(--text-muted);
+}
+
+.prompt-instruction-command {
+  font-weight: 600;
+}
+
+.clickable-icon {
+  border-radius: 6px;
+  padding: 2px;
+  margin: 0 3px;
+}
+
+.clickable-icon[aria-label="Delete workspace"] {
+  margin-top: 4px;
+}
+
+.clickable-icon.mod-error,
+.modal .community-plugin-info button.mod-error {
+  color: var(--text-on-accent);
+}
+
+/*  ----------------------------------------------------------------
+CUSTOM/READABLE LINE WIDTH 
+----------------------------------------------------------------*/
+
+.mod-root #calendar-container.is-readable-line-width,
+.markdown-preview-view.is-readable-line-width .markdown-preview-sizer {
+  max-width: var(--max-width);
+  width: var(--line-width);
+}
+
+.mod-root .markdown-source-view.is-readable-line-width .CodeMirror,
+.mod-root .is-readable-line-width .markdown-preview-section {
+  padding-left: 0;
+  padding-right: 0;
+  margin: 0 auto 0 auto;
+  width: var(--line-width);
+  max-width: var(--max-width);
+}
+
+.markdown-preview-view.is-readable-line-width .markdown-preview-sizer {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: var(--max-width);
+  width: var(--line-width);
+}
+
+.markdown-source-view.mod-cm6 {
+  height: 100%;
+  max-width: var(--max-width);
+  width: var(--line-width) !important;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.markdown-embed-content .markdown-preview-sizer {
+  padding-top: 0;
+}
+
+.markdown-preview-view:not(.is-readable-line-width)
+  .markdown-embed
+  .markdown-preview-sizer {
+  padding-left: 1em;
+  padding-right: 1em;
+}
+
+.markdown-embed.is-readable-line-width .markdown-preview-section {
+  margin: 0;
+  width: auto;
+  max-width: none;
+}
+
+.is-readable-line-width .markdown-preview-section {
+  margin: 0 auto 0 auto;
+  width: var(--line-width);
+  max-width: var(--max-width);
+}
+
+body:not(.is-mobile) .markdown-preview-view .markdown-preview-sizer,
+body:not(.is-mobile)
+  .markdown-preview-view.is-readable-line-width
+  .markdown-preview-sizer {
+  padding-left: 1em;
+  padding-right: 1em;
+}
+
+body.is-mobile .markdown-preview-view .markdown-preview-sizer,
+body.is-mobile
+  .markdown-preview-view.is-readable-line-width
+  .markdown-preview-sizer {
+  padding-left: 2px;
+  padding-right: 2px;
+}
+
+.markdown-preview-section {
+  padding-top: 0.5rem;
+}
+
+html .CodeMirror-lines {
+  padding-top: 3rem;
+}
+
+.markdown-embed .markdown-preview-section {
+  width: auto;
+  max-width: none;
+}
+
+body:not(.is-mobile) .markdown-embed .markdown-preview-view {
+  padding: 20px 20px 20px 20px;
+}
+
+/*NOTES IS SIDE PANE*/
+
+.workspace-tabs .markdown-preview-view {
+  padding-left: 2px;
+  padding-right: 2px;
+}
+
+/* ----------------------------------------------------------------
+WINDOWS & LINUX TITLE BOTTONS
+----------------------------------------------------------------*/
+
+element.style {
+}
+.mod-linux .titlebar-button, .mod-windows .titlebar-button {
+    padding: 5pt 5pt;
+}
+
+/* ----------------------------------------------------------------
+LISTS  
+----------------------------------------------------------------*/
+
+li::marker {
+  color: inherit;
+  -webkit-font-smoothing: auto;
+}
+
+body:not(.is-mobile) ul li::marker {
+  font-family: Karmilla;
+  font-weight: 500;
+}
+
+/*----------------------------------------------------------------
+ORDERED LISTS STYLING
+----------------------------------------------------------------*/
+
+ol {
+  list-style-type: decimal;
+}
+ol ol {
+  list-style-type: lower-alpha;
+}
+ol ol ol {
+  list-style-type: decimal;
+}
+ol ol ol ol {
+  list-style-type: lower-alpha;
+}
+
+ol ol ol ol ol {
+  list-style-type: decimal;
+}
+ol ol ol ol ol ol {
+  list-style-type: lower-alpha;
+}
+ol ol ol ol ol ol ol {
+  list-style-type: decimal;
+}
+ol ol ol ol ol ol ol ol {
+  list-style-type: lower-alpha;
+}
+
+ol ol ol ol ol ol ol ol ol {
+  list-style-type: decimal;
+}
+ol ol ol ol ol ol ol ol ol ol {
+  list-style-type: lower-alpha;
+}
+ol ol ol ol ol ol ol ol ol ol ol {
+  list-style-type: decimal;
+}
+ol ol ol ol ol ol ol ol ol ol ol ol {
+  list-style-type: lower-alpha;
+}
+
+ol ol ol ol ol ol ol ol ol ol ol ol ol {
+  list-style-type: decimal;
+}
+ol ol ol ol ol ol ol ol ol ol ol ol ol ol {
+  list-style-type: lower-alpha;
+}
+ol ol ol ol ol ol ol ol ol ol ol ol ol ol ol {
+  list-style-type: decimal;
+}
+ol ol ol ol ol ol ol ol ol ol ol ol ol ol ol ol {
+  list-style-type: lower-alpha;
+}
+
+/*----------------------------------------------------------------
+UNORDERED LISTS STYLING
+----------------------------------------------------------------*/
+
+ul,
+.is-mobile ul ul ul,
+.is-mobile ol ul ul ul {
+  list-style-type: disc;
+}
+ul ul,
+ol ul ul,
+.is-mobile ul ul ul ul,
+.is-mobile ol ul ul ul ul {
+  list-style-type: circle;
+}
+
+body:not(.is-mobile) ul ul ul,
+body:not(.is-mobile) ol ul ul ul {
+  list-style-type: "▪   ";
+}
+body:not(.is-mobile) ul ul ul ul,
+body:not(.is-mobile) ol ul ul ul ul {
+  list-style-type: "□   ";
+}
+
+ul ul ul ul ul,
+ol ul ul ul ul ul,
+.is-mobile ul ul ul ul ul ul ul,
+.is-mobile ol ul ul ul ul ul ul ul {
+  list-style-type: disc;
+}
+ul ul ul ul ul ul,
+ol ul ul ul ul ul ul,
+.is-mobile ul ul ul ul ul ul ul ul,
+.is-mobile ol ul ul ul ul ul ul ul ul {
+  list-style-type: circle;
+}
+body:not(.is-mobile) ul ul ul ul ul ul ul,
+body:not(.is-mobile) ol ul ul ul ul ul ul ul {
+  list-style-type: "▪   ";
+}
+body:not(.is-mobile) ul ul ul ul ul ul ul ul,
+body:not(.is-mobile) ol ul ul ul ul ul ul ul ul {
+  list-style-type: "□   ";
+}
+
+ul ul ul ul ul ul ul ul ul,
+ol ul ul ul ul ul ul ul ul ul,
+.is-mobile ul ul ul ul ul ul ul ul ul ul ul,
+.is-mobile ol ul ul ul ul ul ul ul ul ul ul ul {
+  list-style-type: disc;
+}
+ul ul ul ul ul ul ul ul ul ul,
+ol ul ul ul ul ul ul ul ul ul ul,
+.is-mobile ul ul ul ul ul ul ul ul ul ul ul ul,
+.is-mobile ol ul ul ul ul ul ul ul ul ul ul ul ul {
+  list-style-type: circle;
+}
+body:not(.is-mobile) ul ul ul ul ul ul ul ul ul ul ul,
+body:not(.is-mobile) ol ul ul ul ul ul ul ul ul ul ul ul {
+  list-style-type: "▪   ";
+}
+body:not(.is-mobile) ul ul ul ul ul ul ul ul ul ul ul ul,
+body:not(.is-mobile) ol ul ul ul ul ul ul ul ul ul ul ul ul {
+  list-style-type: "□   ";
+}
+
+/*----------------------------------------------------------------
+TASK LISTS
+----------------------------------------------------------------*/
+
+.markdown-preview-view ul > li.task-list-item > p {
+  text-indent: unset;
+}
+
+input[type="checkbox"],
+.markdown-preview-view .task-list-item-checkbox {
+  cursor: pointer;
+  width: 1rem;
+  height: 1rem;
+  padding: 0;
+  position: relative;
+  -webkit-appearance: none;
+  appearance: none;
+  position: relative;
+  line-height: 0;
+  right: 3px;
+  margin-left: 3px;
+  margin-right: 4px !important;
+  filter: none;
+  margin-bottom: 0;
+  top: 2px;
+  box-sizing: border-box;
+  background-color: var(--background-primary-alt);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 3px;
+  box-shadow: inset 0px 0.5px 1px var(--background-zero);
+}
+
+input[type="checkbox"],
+.markdown-source-view.mod-cm6 .task-list-item-checkbox {
+  vertical-align: top;
+}
+
+.is-mobile input[type="checkbox"],
+.is-mobile .markdown-preview-view .task-list-item-checkbox {
+  margin-left: 3px;
+  margin-right: 5px !important;
+}
+
+/* remove duplicated checkbox checked symbol */
+input[type=checkbox]:checked:after{
+  content: unset;
+}
+
+.is-flashing input[type="checkbox"]:checked:before,
+input[type="checkbox"]:checked:before {
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="white" stroke-width="2" stroke="white" d="M41.667 64.942l-13.721 -13.721l-5.892 5.892L41.667 76.725l40.446 -40.446l-5.892 -5.892z"></path></svg>');
+  background-repeat: no-repeat;
+  background-position: center center;
+  background-size: 125%;
+  line-height: 1;
+  width: 100%;
+  height: 100%;
+  content: " ";
+  display: block;
+}
+
+.markdown-preview-view ul > li.task-list-item {
+  font-weight: normal;
+  color: var(--text-normal);
+}
+
+input[type="checkbox"]:focus,
+input[type="checkbox"]:hover,
+input.task-list-item-checkbox:focus,
+input.task-list-item-checkbox:hover {
+  outline: 0;
+  box-shadow: 0 0 0 0.1px rgba(0, 0, 0, 0.1),
+    0 0 0 3px hsla(var(--accent-hsl), 0.35);
+  border: 1px solid var(--interactive-accent);
+}
+
+.is-flashing input[type="checkbox"]:checked,
+input[type="checkbox"]:checked {
+  background: var(--background-modifier-accent);
+  box-shadow: none;
+  border-color: transparent;
+}
+
+/*task line height*/
+
+ul.contains-task-list li {
+  line-height: var(--editor-line-height) !important;
+  margin: 0;
+}
+
+/*----------------------------------------------------------------
+RELATIONSHIP LINES
+----------------------------------------------------------------*/
+
+body:not(.remove-pre-rel-lines) ul > li,
+body:not(.remove-pre-rel-lines) ol > li {
+  position: relative;
+}
+
+body:not(.remove-pre-rel-lines) ol,
+body:not(.remove-pre-rel-lines) ul {
+  position: relative;
+}
+
+/* Relationship lines in Preview */
+body:not(.remove-pre-rel-lines) .markdown-preview-view ul ul,
+body:not(.remove-pre-rel-lines) .markdown-preview-view ol ol {
+  position: relative;
+}
+
+body:not(.remove-pre-rel-lines) ul > li::before,
+body:not(.remove-pre-rel-lines) ol > li::before {
+  content: "";
+  border-left-width: var(--custom-pre-line-thickness);
+  border-left-style: solid;
+  border-left-color: var(--background-modifier-border);
+  opacity: 0.8;
+  position: absolute;
+  height: calc(100% - 2em);
+  margin-left: -0.85em;
+  left: -0.05em;
+  top: 2em;
+  bottom: 0;
+}
+
+body:not(.remove-pre-rel-lines) ul ul::before,
+body:not(.remove-pre-rel-lines) ol ol::before {
+  content: "";
+  position: absolute;
+}
+
+body:not(.remove-pre-rel-lines) .markdown-preview-view ol ol::before {
+  margin-left: -0.8em;
+}
+
+/* Relationship line spacing fix for tasks lists */
+body:not(.remove-pre-rel-lines)
+  .markdown-preview-view
+  .task-list-item-checkbox {
+  left: -1px;
+  margin-right: 5px;
+}
+
+body:not(.remove-pre-rel-lines)
+  .markdown-preview-view
+  ul.contains-task-list
+  ul::before,
+body:not(.remove-pre-rel-lines)
+  .markdown-preview-view
+  ol.contains-task-list
+  ol::before {
+  left: -0.1em;
+  bottom: 0.3em;
+}
+
+/* Relationship lines in Edit mode  */
+body:not(.remove-ed-rel-lines) .cm-s-obsidian > .cm-tab,
+body:not(.remove-ed-rel-lines) .cm-hmd-list-indent > .cm-tab,
+body:not(.remove-ed-rel-lines) .rel-lines-edit .cm-hmd-list-indent > .cm-tab {
+  position: relative;
+}
+
+body:not(.remove-ed-rel-lines) .cm-hmd-list-indent > .cm-tab:before,
+body:not(.remove-ed-rel-lines)
+  .rel-lines-edit
+  .cm-hmd-list-indent
+  > .cm-tab:before,
+body:not(.remove-ed-rel-lines) .cm-hmd-list-indent .cm-tab::before {
+  content: "";
+  display: block;
+  position: absolute;
+  opacity: 0.35;
+  top: 0.25em;
+  left: 0.3em;
+  border-left-width: var(--custom-ed-line-thickness);
+  border-left-style: solid;
+  border-left-color: var(--text-faint);
+  height: 100%;
+}
+
+.cm-s-obsidian .HyperMD-list-line {
+  padding-top: 0;
+}
+
+/*----------------------------------------------------------------
+EMBEDS
+----------------------------------------------------------------*/
+
+.view-content img {
+  max-width: 100%;
+}
+
+.markdown-preview-section img {
+  max-width: 100%;
+  display: inline-block;
+}
+
+.markdown-preview-view img:not(img.emoji):not([width]) {
+  margin: inherit auto;
+}
+
+.markdown-preview-view img:not(img.emoji):not([width]),
+.markdown-preview-view audio,
+.markdown-preview-view video {
+  max-width: 100%;
+  display: block;
+}
+
+.workspace-leaf-content[data-type="pdf"] .view-content {
+  padding: 0px;
+  overflow: auto;
+}
+
+/*EMBEDDED NOTES */
+
+.file-embed-icon {
+  vertical-align: -5.5px;
+}
+
+.file-embed-title,
+.markdown-embed-title {
+  font-size: 15px;
+}
+
+.markdown-embed-title {
+  font-weight: 600;
+}
+
+.dice-roller.has-embed .internal-embed .markdown-embed {
+  padding-left: 26px;
+  padding-right: 26px;
+}
+
+.internal-embed .markdown-embed {
+  border: 1px solid var(--background-modifier-border);
+  background-color: var(--background-primary-alt);
+  /*box-shadow: 0px 0.5px 1px 0.5px rgba(0, 0, 0, 0.8);*/
+  border-radius: 6px;
+}
+
+.markdown-preview-view .markdown-embed {
+  margin: 1rem 0 1rem 0;
+  padding-left: 0;
+  padding-right: 0;
+  /*restore embed rounded box in v.1.1.8*/
+  border: 1px solid var(--background-modifier-border);
+  background-color: var(--background-primary-alt);
+  border-radius: 6px;
+}
+
+/* remove strange white rectangle in embedded box  */
+/* .markdown-preview-view .markdown-embed-content {
+  overflow: scroll;
+} */
+
+/* adjust embedded box max height */
+.markdown-preview-view .markdown-embed-content {
+  /*max-height: none !important;*/
+  max-height: 600px;
+}
+
+/* fix embedded box content overflow in page preview */
+.inline-embed .markdown-embed-content {
+  height: 90%;
+}
+
+.embed-title {
+  display: block; /* set title text alignment as center */
+  font-size: small;
+}
+
+.markdown-embed-title {
+  font-weight: var(--bold-weight);
+  text-align: center; /* set title text alignment as center */
+  text-overflow: ellipsis;
+  /*white-space: nowrap;*/
+  white-space: inherit; /* title wrapping */
+  margin-right: 10pt;
+  padding: 0 var(--size-4-2) var(--size-4-2) var(--size-4-2); /* title padding */
+}
+
+.markdown-embed-content .markdown-preview-section {
+  min-height: 0 !important;
+}
+
+.markdown-embed .markdown-preview-section {
+  padding: 0;
+  margin: 0;
+  width: auto;
+  max-width: none;
+}
+
+.markdown-embed-content .markdown-preview-section {
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.markdown-preview-view .markdown-embed-content img {
+  max-width: 100%;
+}
+
+/*embedded notes containing tasks*/
+
+.task-list-item > .internal-embed {
+  margin-top: -2.5em;
+  margin-bottom: 1em;
+  padding-left: 0.5em;
+  display: contents;
+}
+
+/*----------------------------------------------------------------
+AUDIO 
+----------------------------------------------------------------*/
+
+audio,
+.theme-dark audio {
+  width: 100% !important;
+  filter: unset !important;
+}
+
+audio::-webkit-media-controls-enclosure {
+  border-radius: 4px;
+  height: 15px;
+  width: 100% !important;
+  box-shadow: 0px 1px 1px rgb(0 0 0 / 8%);
+}
+
+.theme-light audio::-webkit-media-controls-enclosure {
+  background-color: var(--background-secondary-alt);
+  opacity: 0.9;
+}
+
+.theme-dark audio::-webkit-media-controls-enclosure {
+  filter: sepia(15%) contrast(100%) invert(90%);
+  opacity: 0.9;
+}
+
+/*----------------------------------------------------------------
+IFRAME 
+----------------------------------------------------------------*/
+
+iframe {
+  border: none;
+}
+
+/*----------------------------------------------------------------
+IMAGES
+----------------------------------------------------------------*/
+
+figure {
+  margin: auto;
+}
+
+figcaption {
+  background-color: black;
+  color: white;
+  font-style: italic;
+  padding: 2px;
+  text-align: center;
+}
+
+/*----------------------------------------------------------------
+IMAGE ALT SIZING
+----------------------------------------------------------------*/
+
+.cm-formatting.cm-formatting-quote.cm-formatting-quote-1.cm-quote.cm-quote-1
+  span[alt*="The"] {
+  color: red;
+}
+
+.grid span.image-embed[alt*="."],
+span[alt*="grid"] {
+  display: table-cell;
+  vertical-align: middle;
+  padding: 3px;
+}
+
+img[alt*="grid"],
+.grid img[alt*="."] {
+  max-height: 30vh;
+}
+
+/* Floating Images */
+img[alt*="left"] {
+  float: left;
+  clear: left;
+  margin-right: 1rem;
+  margin-bottom: 4px;
+  margin-top: 4px;
+}
+
+img[alt*="right"] {
+  float: right;
+  clear: right;
+  margin-left: 1rem;
+  margin-bottom: 4px;
+  margin-top: 4px;
+}
+img[alt*="center"],
+img[alt*="centre"] {
+  display: block;
+  margin-right: auto;
+  margin-left: auto;
+  margin-bottom: 4px;
+  margin-top: 4px;
+}
+
+.theme-dark img[alt*="invertdark"] {
+  filter: invert(1) hue-rotate(180deg);
+  background-color: hsla(
+    var(--base-h),
+    calc(var(--base-s) - 100%),
+    calc(var(--base-l) + 24%),
+    0.25
+  ) !important;
+}
+
+.theme-light img[alt*="invertlight"] {
+  filter: invert(1) hue-rotate(0deg);
+  background-color: hsla(
+    var(--base-h),
+    calc(var(--base-s) - 100%),
+    calc(var(--base-l) - 45%),
+    0.25
+  ) !important;
+}
+
+/*IMAGE EMBED SIZE FIX*/
+
+.image-container {
+  width: 75%;
+  margin: 0 auto;
+  cursor: zoom-in;
+}
+
+.markdown-preview-section img.emoji {
+  display: inline;
+  margin: 0;
+}
+
+.markdown-preview-view img:hover{
+  max-height: 50%;
+}
+
+/*----------------------------------------------------------------
+IMAGE ZOOM */
+
+.markdown-preview-view img {
+  cursor: zoom-in;
+}
+
+.markdown-preview-view img:active,
+.image-container img:active {
+  cursor: zoom-out;
+  display: block;
+  z-index: 100;
+  position: fixed;
+  margin: 0em 0em !important;
+  max-height: calc(100% + 25px);
+  max-width: calc(100% - 0px);
+  height: calc(100% + 1px);
+  width: 100%;
+  object-fit: contain;
+  margin: -0.5px auto 0;
+  text-align: center;
+  /*
+top: 50%;
+transform: translateY(-50%);*/
+  padding: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  mix-blend-mode: normal;
+  background-color: var(--background-translucent);
+}
+
+/*Image filters */
+
+/*Credit to @kepano https://discord.com/channels/686053708261228577/702656734631821413/828012547905945652*/
+
+span[src$="#grayscale"] img {
+  filter: grayscale(100%);
+  background: var(--background-primary);
+}
+
+span[src$="#saturate"] img {
+  background: var(--background-primary);
+  filter: saturate(7);
+}
+span[src$="#sepia"] img {
+  background: var(--background-primary);
+  filter: sepia(100%);
+}
+
+img[alt*="rotate90"] {
+  transform: rotate(90deg);
+}
+
+span[src$="#rotate90"] img {
+  transform: rotate(90deg);
+}
+
+span[src$="#rotate180"] img {
+  transform: rotate(180deg);
+}
+
+span[src$="#rotate270"] img {
+  transform: rotate(270deg);
+}
+
+/*----------------------------------------------------------------
+POP-OVER ANIMATION
+----------------------------------------------------------------*/
+
+@keyframes pop-pop {
+  0% {
+    opacity: 0;
+    transform: scale(1);
+  }
+  20% {
+    opacity: 0.7;
+    transform: scale(1.02);
+  }
+  40% {
+    opacity: 1;
+    transform: scale(1.05);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+/*----------------------------------------------------------------
+BIGGER POPOVERS
+----------------------------------------------------------------*/
+
+div.popover.hover-popover {
+  border-radius: 6px;
+  animation: 300ms ease-in-out;
+  transform: ease-in;
+  transition: ease-out;
+  width: 24rem;
+  background-color: var(--background-primary);
+  border: 1px solid var(--background-modifier-border) !important;
+  max-height: 100%;
+}
+
+/*no scrollbars in popover*/
+div.popover.hover-popover ::-webkit-scrollbar {
+  display: none;
+}
+
+div.popover.hover-popover .markdown-preview-view {
+  padding-bottom: 2.5rem;
+  padding-top: 1.5rem !important;
+  padding: 1.5rem;
+  font-size: calc(var(--editor-font-size) - 0.1rem);
+}
+
+.popover.hover-popover .markdown-embed {
+  height: 18rem;
+}
+
+/* fix popover image preview sizing issue */
+.popover.hover-popover img:not(img.emoji):not([width]), .markdown-preview-view audio, .markdown-preview-view video {
+  width: 24rem;
+  margin-bottom: -6pt;
+}
+
+/*----------------------------------------------------------------
+SCROLLBARS
+----------------------------------------------------------------*/
+
+::-webkit-scrollbar {
+  width: 10px !important;
+  height: 10px;
+  background-color: transparent;
+}
+
+.mod-root::-webkit-scrollbar-track {
+  background-color: var(--background-primary);
+}
+
+::-webkit-scrollbar-thumb {
+  background-clip: padding-box;
+  border: 3px solid transparent;
+  min-height: 40px;
+  background-color: var(--background-tertiary);
+  border-radius: 0;
+}
+
+::-webkit-scrollbar-thumb:active {
+  background-color: var(--background-tertiary);
+  border-radius: 0;
+  cursor: grabbing;
+  cursor: -moz-grabbing;
+  cursor: -webkit-grabbing;
+}
+
+.CodeMirror-scroll::-webkit-scrollbar-track,
+.CodeMirror-scroll::-webkit-scrollbar-thumb,
+.CodeMirror-scroll::-webkit-scrollbar {
+  opacity: 0;
+  border: none;
+  background-color: transparent;
+}
+
+.CodeMirror-vscrollbar,
+.CodeMirror-hscrollbar,
+.CodeMirror-scrollbar-filler {
+  z-index: 0;
+}
+
+.mod-root .CodeMirror-gutter.CodeMirror-linenumbers,
+.mod-root .CodeMirror-gutter.CodeMirror-foldgutter {
+  background-color: var(--background-primary);
+}
+
+.modal .vertical-tab-header::-webkit-scrollbar-track,
+.mod-left-split .workspace-tabs ::-webkit-scrollbar-track {
+  background-color: transparent;
+}
+
+/*----------------------------------------------------------------
+WORKSPACE 
+----------------------------------------------------------------*/
+
+.workspace-leaf.is-highlighted:before {
+  background-color: var(--interactive-accent);
+  opacity: 0.15;
+}
+
+.view-header.is-highlighted::after {
+  background-color: var(--interactive-accent);
+  opacity: 0.15;
+}
+
+.markdown-preview-view .mod-highlighted {
+  transition: background-color 0.3s ease;
+  background-color: var(--text-selection);
+  color: inherit;
+}
+
+.workspace-split.mod-vertical > .workspace-split {
+  padding: 0;
+}
+
+.workspace-split.mod-root {
+  background-color: var(--background-secondary);
+}
+
+/* remove right border of the left side bar */
+.workspace-ribbon{
+  border-right: unset;
+}
+
+/* remove bottom border of the left-up cornor */
+.workspace-ribbon.mod-left:before{
+  border-bottom: unset;
+  height: calc(var(--header-height) - var(--tab-outline-width) + 1pt);
+}
+
+.workspace-ribbon.side-dock-ribbon.mod-left.is-collapsed {
+  border-right-color: var(--background-primary-alt);
+}
+
+.workspace-ribbon.side-dock-ribbon.mod-right.is-collapsed {
+  border-left-color: var(--background-primary-alt);
+}
+
+.view-header,
+.workspace-leaf.mod-active .view-header,
+.workspace-split.mod-root
+  > .workspace-leaf:first-of-type:last-of-type
+  .view-header,
+.workspace
+  > .mod-root
+  > .workspace-leaf
+  > .workspace-leaf-content
+  > .view-header {
+  background-color: var(--background-primary);
+}
+
+.workspace-ribbon.mod-right.is-collapsed,
+.workspace-ribbon.mod-left.is-collapsed {
+  background-color: var(--background-primary) !important;
+}
+
+.workspace-ribbon .workspace-ribbon-collapse-btn,
+.workspace-ribbon.mod-left .workspace-ribbon-collapse-btn {
+  transition: none;
+}
+
+body:not(.is-mobile):not(.disable-side-animation) .workspace-ribbon.mod-right,
+body:not(.is-mobile):not(.disable-side-animation) .workspace-ribbon.mod-left {
+  transition: border-color 0s ease-in-out 0s, background-color 0s ease-in-out 0s;
+}
+
+.workspace-ribbon.mod-right.is-collapsed,
+.workspace-ribbon.mod-left.is-collapsed {
+  border-color: transparent;
+}
+
+body:not(.is-mobile):not(.disable-side-animation)
+  .workspace-ribbon.mod-right.is-collapsed,
+body:not(.is-mobile):not(.disable-side-animation)
+  .workspace-ribbon.mod-left.is-collapsed {
+  transition: border-color 0s ease-in-out 0.1s,
+    background-color 0s ease-in-out 0.2s;
+}
+
+body:not(.is-mobile):not(.disable-side-animation)
+  .is-translucent
+  .workspace-ribbon.mod-right.is-collapsed,
+body:not(.is-mobile):not(.disable-side-animation)
+  .is-translucent
+  .workspace-ribbon.mod-left.is-collapsed {
+  transition: border-color 0s ease-in-out 0.1s,
+    background-color 0s ease-in-out 0.2s;
+}
+
+.disable-side-animation .workspace-ribbon,
+.disable-side-animation .workspace-ribbon,
+.disable-side-animation .workspace-split.mod-right-split,
+.disable-side-animation .workspace-split.mod-left-split {
+  transition: none !important;
+}
+
+/*WORKSPACE RESIZE HANDLE*/
+
+.workspace-leaf-resize-handle {
+  z-index: 11;
+}
+
+body:not(.is-mobile) .workspace-leaf-resize-handle {
+  transition: background-color 200ms ease-in-out, box-shadow 200ms ease-in-out;
+}
+
+.workspace-split.mod-root.mod-horizontal .workspace-leaf-resize-handle,
+.workspace-split.mod-root.mod-vertical .workspace-leaf-resize-handle {
+  border-width: 0;
+  background-color: var(--background-primary-alt);
+}
+
+.theme-dark
+  .workspace-split.mod-root.mod-horizontal
+  .workspace-leaf-resize-handle,
+.theme-dark
+  .workspace-split.mod-root.mod-vertical
+  .workspace-leaf-resize-handle {
+  background-color: var(--background-primary-alt);
+}
+.workspace-split.mod-horizontal > * > .workspace-leaf-resize-handle {
+  height: 1px;
+  border-bottom: none;
+}
+.workspace-split.mod-vertical > * > .workspace-leaf-resize-handle,
+.workspace-split.mod-left-split > .workspace-leaf-resize-handle,
+.workspace-split.mod-right-split > .workspace-leaf-resize-handle {
+  width: 2px;
+}
+
+.workspace-split.mod-right-split > .workspace-leaf-resize-handle {
+  border-left: none;
+  background-color: var(--background-primary-alt);
+  width: 2px;
+  top: 0;
+}
+
+.theme-dark .workspace-split.mod-left-split > .workspace-leaf-resize-handle,
+.theme-dark .workspace-split.mod-right-split > .workspace-leaf-resize-handle {
+  background-color: var(--background-primary-alt);
+}
+
+.workspace-split.mod-right-split > .workspace-leaf-resize-handle,
+.workspace-split.mod-left-split > .workspace-leaf-resize-handle {
+  background: transparent;
+  border-right: none;
+  width: 2px !important;
+  top: 0;
+}
+
+.workspace-split.mod-right-split > .workspace-leaf-resize-handle:active,
+.workspace-split.mod-vertical > * > .workspace-leaf-resize-handle:active,
+.workspace-split.mod-left-split > .workspace-leaf-resize-handle:active {
+  border-width: 0;
+  background-color: hsla(var(--accent-hsl), 0.15) !important;
+  box-shadow: 1px 0 0 hsla(var(--accent-hsl), 0.15),
+    -1px 0 0 hsla(var(--accent-hsl), 0.15);
+}
+
+.workspace-split.mod-horizontal > * > .workspace-leaf-resize-handle:active {
+  background-color: hsla(var(--accent-hsl), 0.15) !important;
+  box-shadow: 0 1px 0 hsla(var(--accent-hsl), 0.15),
+    0 -1px 0 hsla(var(--accent-hsl), 0.15);
+}
+
+.workspace-tabs .workspace-leaf-resize-handle {
+  background-color: var(--background-modifier-border);
+}
+
+.workspace-split.mod-left-split > .workspace-leaf-resize-handle,
+.workspace-split.mod-right-split > .workspace-leaf-resize-handle {
+  height: 100%;
+}
+
+/*pretty cursor*/
+
+.CodeMirror-cursor,
+.cm-s-obsidian .cm-cursor {
+  border-left: 2px solid var(--vim-cursor);
+}
+
+/*WORKSPACE TABS*/
+
+/* remove tab panel's bottom border */
+.workspace-tab-header-container {
+  border-bottom: unset;
+  padding: 1px 10px 1px 10px;
+}
+
+.workspace-tab-header.is-active {
+  box-shadow: 0px 0px 1px 1px inset var(--background-tertiary);
+  background-color: var(--background-primary);
+  border-radius: 6px;
+}
+
+.theme-dark .workspace-tab-header.is-active {
+  box-shadow: 0px 0px 0px 1px inset var(--background-tertiary);
+}
+
+.workspace-tab-header,
+.workspace-tab-header-inner,
+.workspace-tab-container-before,
+.workspace-tab-container-after {
+  transition: none;
+}
+
+.workspace-tab-container-before.is-before-active,
+.workspace-tab-container-after.is-after-active,
+.workspace-tab-header.is-before-active,
+.workspace-tab-header.is-after-active {
+  background: transparent;
+}
+
+.workspace-tab-container-after .workspace-tab-header-inner,
+.workspace-tab-container-after.is-after-active .workspace-tab-header-inner,
+.workspace-tab-container-before.is-before-active .workspace-tab-header-inner,
+.workspace-tab-header.is-before-active .workspace-tab-header-inner,
+.workspace-tab-header.is-after-active,
+.workspace-tab-header.is-after-active .workspace-tab-header-inner,
+.workspace-tab-header.is-before-active,
+.workspace-tab-header.is-after-active {
+  background: transparent;
+}
+
+/* unified sidebar header background */
+/*.workspace-tab-header-container {
+  background-color: transparent;
+}*/
+
+/*WORKSPACE TAB ICON*/
+
+.workspace-tab-header-inner-icon {
+  display: flex;
+  padding: 4px 4px;
+}
+
+.workspace-tab-header-inner {
+  padding: 6px;
+}
+
+/*WORKSPACE TAB RADIUS*/
+
+.workspace-tab-container-after.is-after-active .workspace-tab-header-inner,
+.workspace-tab-header.is-after-active .workspace-tab-header-inner,
+.workspace-tab-container-before.is-before-active .workspace-tab-header-inner,
+.workspace-tab-header.is-before-active .workspace-tab-header-inner {
+  border-bottom-right-radius: 0px;
+  border-bottom-left-radius: 0px;
+}
+
+.workspace-tab-header,
+.workspace-tab-header.is-before-active .workspace-tab-header-inner,
+.workspace-tab-header.is-after-active .workspace-tab-header-inner {
+  border-bottom-left-radius: 3px;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
+}
+
+/*WORKSPACE LEAF RADIUS*/
+
+.workspace-split.mod-left-split .workspace-tabs .workspace-leaf,
+.workspace-split.mod-right-split .workspace-tabs .workspace-leaf {
+  border-bottom-left-radius: 0px;
+  border-top-left-radius: 0px;
+  border-top-right-radius: 0px;
+  border-bottom-right-radius: 0px;
+}
+
+.workspace-split.mod-root
+  > .workspace-leaf:first-of-type
+  .workspace-leaf-content,
+.workspace-split.mod-root
+  > .workspace-leaf:last-of-type
+  .workspace-leaf-content {
+  border-top-right-radius: 0px;
+  border-top-left-radius: 0px;
+}
+
+/*----------------------------------------------------------------
+Header */
+
+body:not(.is-mobile) .nav-action-button svg {
+  height: 17px;
+  width: 17px;
+}
+
+.nav-action-button {
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 10px !important;
+  padding-top: 10px !important;
+  padding-bottom: 3px !important;
+  margin: 1px !important;
+  border-radius: 6px;
+}
+
+.workspace-split .nav-action-button {
+  transition: 50ms ease-in-out;
+}
+
+.nav-action-text-button,
+.nav-action-text-button:hover {
+  transition: 100ms ease-in-out;
+}
+
+body:not(.plugin-sliding-panes-rotate-header)
+  .workspace-leaf-content[data-type="markdown"]
+  .workspace-leaf-header,
+body:not(.plugin-sliding-panes-rotate-header)
+  .workspace-leaf-content[data-type="kanban"]
+  .view-header,
+body:not(.plugin-sliding-panes-rotate-header)
+  .workspace-leaf-content[data-type="markdown"]
+  .view-header {
+  /*box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.06);*/ /*cancel workspace-leaf-content header shadow*/
+  position: relative;
+}
+
+body:not(.is-mobile):not(.plugin-sliding-panes-rotate-header)
+  .workspace-leaf-content[data-type="markdown"]
+  .workspace-leaf-header,
+body:not(.is-mobile):not(.plugin-sliding-panes-rotate-header)
+  .workspace-leaf-content[data-type="kanban"]
+  .view-header,
+body:not(.is-mobile):not(.plugin-sliding-panes-rotate-header)
+  .workspace-leaf-content[data-type="markdown"]
+  .view-header {
+  z-index: 10;
+}
+
+body.theme-dark:not(.plugin-sliding-panes-rotate-header)
+  .workspace-leaf-content[data-type="markdown"]
+  .workspace-leaf-header,
+body.theme-dark:not(.plugin-sliding-panes-rotate-header)
+  .workspace-leaf-content[data-type="markdown"]
+  .view-header {
+  box-shadow: 0px 1px 4px rgba(25, 25, 25, 0.3);
+}
+
+body
+  .workspace
+  > .mod-root
+  > .workspace-leaf
+  > .workspace-leaf-content
+  > .view-header
+  > .view-header-title-container::after,
+body
+  .workspace
+  > .mod-root
+  > .workspace-leaf.mod-active
+  > .workspace-leaf-content
+  > .view-header
+  > .view-header-title-container::after {
+  content: none !important;
+  position: absolute;
+  bottom: 100px !important;
+  top: unset;
+  right: 0;
+  width: 26px;
+  height: 26px;
+  background: linear-gradient(
+    to bottom,
+    transparent,
+    var(--background-primary)
+  ) !important;
+}
+
+.workspace-split.mod-vertical > .workspace-leaf {
+  padding-right: 0px;
+}
+
+body:not(.is-mobile)
+  .workspace-leaf.mod-active
+  > .workspace-leaf-content
+  > .view-header
+  > .view-header-title-container
+  .view-header-title {
+  color: var(--text-normal);
+  font-size: 15px;
+  font-weight: 500;
+}
+
+body:not(.is-mobile) .view-header-title {
+  /*note header size might be unneeded*/
+  font-size: 15px;
+  color: var(--text-muted);
+  font-weight: 500;
+  padding: 1px 0;
+}
+
+body:not(.plugin-sliding-panes-rotate-header) .view-header-title {
+  padding: 1px 0;
+  margin-left: 7px;
+  display: flex;
+}
+
+.view-header-title-container:after {
+  display: none;
+}
+
+/*----------------------------------------------------------------
+TAGS
+----------------------------------------------------------------*/
+
+.token.tag {
+  padding: 0px 0px;
+  background-color: transparent;
+  border: none;
+}
+
+.token.tag:hover {
+  background: transparent;
+  color: var(--text-normal) !important;
+}
+
+/*----------------------------------------------------------------
+TAG PILLS
+----------------------------------------------------------------*/
+.markdown-preview-section h1 a.tag,
+.markdown-preview-section h2 a.tag,
+.markdown-preview-section h3 a.tag,
+.markdown-preview-section h4 a.tag,
+.markdown-preview-section h5 a.tag,
+.markdown-preview-section h4 a.tag {
+  font-weight: inherit;
+}
+
+.tag {
+  background-color: var(--tag-base);
+  border: 1px solid var(--interactive-accent);
+  color: var(--text-normal);
+  font-weight: 500;
+  padding: 1.5px 6px;
+  padding-left: 6px;
+  padding-right: 6px;
+  text-align: center;
+  text-decoration: none !important;
+  display: inline-block;
+  cursor: pointer;
+  border-radius: 8px;
+  transition: 0.2s ease-in-out;
+}
+
+.tag:hover {
+  color: var(--interactive-accent);
+}
+
+/*----------------------------------------------------------------
+TAG REF STYLING
+----------------------------------------------------------------*/
+
+.tag[href^="#❗️"],
+.tag[href^="#important❗️"] {
+  background-color: var(--tag-base);
+  border: 1px solid var(--boldred);
+}
+
+.tag[href^="#📓"],
+.tag[href^="#journal📓"] {
+  background-color: var(--tag-base);
+  border: 1px solid var(--purple);
+}
+
+.tag[href^="#🌱"],
+.tag[href^="#seedling🌱"],
+.tag[href^="#🌿"],
+.tag[href^="#budding🌿"],
+.tag[href^="#🌳"],
+.tag[href^="#evergreen🌳"] {
+  background-color: var(--tag-base);
+  border: 1px solid var(--boldgreen);
+}
+
+/*----------------------------------------------------------------
+GRAPH SETTINGS
+----------------------------------------------------------------*/
+
+.graph-view.color-fill-attachment {
+  color: var(--graph-fill-attachment) !important;
+}
+
+.graph-view.color-fill-unresolved {
+  color: var(--graph-circle-fill-unresolved);
+  opacity: 0.3;
+}
+
+.graph-view.color-arrow {
+  color: var(--graph-arrow);
+  opacity: 0.7;
+}
+
+.theme-dark .graph-view.color-line {
+  color: var(--graph-line);
+  opacity: 1;
+}
+
+.theme-light .graph-view.color-line {
+  color: var(--graph-line);
+  opacity: 0.3;
+}
+
+.graph-view.color-line-highlight {
+  color: var(--graph-line-highlight);
+}
+
+.theme-dark .graph-view.color-fill-tag {
+  color: var(--graph-fill-tag);
+}
+
+.theme-light .graph-view.color-fill-tag {
+  color: var(--graph-fill-tag);
+}
+
+.graph-view.color-circle {
+  color: var(--graph-circle-outline);
+}
+
+.graph-view.color-fill {
+  color: var(--graph-circle-fill);
+}
+
+.graph-view.color-fill-highlight {
+  color: var(--graph-circle-fill-highlight);
+}
+
+/*EMPTY STATE*/
+
+.empty-state-title {
+  line-height: 1em;
+}
+
+.empty-state-action:hover {
+  color: var(--text-faint);
+}
+
+.empty-state-container svg.cross {
+  display: none;
+}
+
+.plugin-sliding-panes-rotate-header .empty-state-container {
+  margin-left: calc(var(--header-width) * 1.3);
+}
+
+body:not(.is-mobile) .empty-state-container {
+  border-radius: 6px;
+  padding: 0.5em 2em 2em 2em;
+  padding-bottom: 1em;
+  border: 5px solid transparent;
+  transition: box-shadow 300ms ease-in-out;
+}
+
+body:not(.is-mobile) .empty-state-container:hover {
+  background-color: hsla(var(--accent-hsl), 0.1);
+  box-shadow: 0px 0.5px 1px 0.5px rgba(0, 0, 0, 0.1),
+    0 0 0 5px hsla(var(--accent-hsl), 0.25);
+  border: 5px solid var(--interactive-accent);
+  border-radius: 6px;
+}
+
+/*mermaid notes*/
+
+.mermaid .today {
+  stroke: red !important;
+}
+
+.mermaid .task {
+  font-size: var(--editor-font-size) !important;
+}
+
+.mermaid text {
+  font-family: var(--font-monospace) !important;
+  font-size: calc(var(--editor-font-size) - 0.3em) !important;
+  line-height: 1.75 !important;
+}
+
+.mermaid .internal-link {
+  font-family: var(--font-monospace) !important;
+}
+
+#m84d0faf0b4897293 .activeText0,
+#m84d0faf0b4897293 .activeText1,
+#m84d0faf0b4897293 .activeText2,
+#m84d0faf0b4897293 .activeText3,
+#m04867152d2cd3bb2 g.classGroup text {
+  fill: var(--text-normal) !important;
+  filter: invert(50%);
+}
+
+/*----------------------------------------------------------------
+STYLING FOR PLUGIN MODES (SLIDING PANES/FOCUS MODE/HIDER ETC.)
+----------------------------------------------------------------*/
+
+.view-header {
+  height: 43px;
+  align-items: center;
+  padding: 6px 9px;
+}
+
+.view-header-title-container {
+  align-items: center;
+  padding-left: 0;
+  padding-right: 0px;
+}
+
+body.plugin-sliding-panes.plugin-sliding-panes-rotate-header.hider-ribbon
+  .workspace
+  > .mod-root
+  > .workspace-leaf
+  > .workspace-leaf-content
+  > .view-header {
+  height: unset;
+  display: flex;
+  align-items: center;
+  padding: 2px 7px 2px 5px !important;
+}
+
+body:not(.plugin-sliding-panes-rotate-header):not(.is-mobile)
+  .workspace-leaf
+  .workspace-leaf-content
+  .view-header-title-container {
+  line-height: 1em;
+  align-items: center;
+}
+
+body:not(.plugin-sliding-panes-rotate-header):not(.is-mobile) .view-actions {
+  background-color: transparent;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  padding-right: 10px;
+}
+
+body:not(.is-mobile) .view-action svg {
+  height: 18px;
+  width: 18px;
+}
+
+body:not(.plugin-sliding-panes-rotate-header):not(.is-mobile)
+  .view-actions
+  .view-action {
+  opacity: 1;
+  display: flex;
+  line-height: 1;
+  padding: 2px;
+  position: static;
+  margin: 0 0 0 3px;
+  align-items: center;
+  justify-content: center;
+}
+
+body:not(.plugin-sliding-panes-rotate-header)
+  .workspace-leaf-content
+  > .view-header
+  .view-action,
+.workspace-leaf-content > .view-header .view-action {
+  margin: 2px 4px;
+}
+
+html
+  > body.plugin-sliding-panes-rotate-header
+  .workspace
+  > .mod-root
+  > .workspace-leaf
+  > .workspace-leaf-content
+  > .view-header
+  .view-header-icon {
+  margin: 18px 0px 0px 0px;
+  display: flex;
+}
+
+/* remove strange icon in view header bar */
+/*body.is-mobile .view-header-icon {
+  margin-left: 5px;
+  cursor: grab;
+  display: inline-flex;
+  justify-content: center;
+  line-height: 1;
+  padding: 4px 6px;
+  position: static;
+  top: 0;
+}*/
+
+body:not(.plugin-sliding-panes-rotate-header):not(.is-mobile)
+  .view-header-icon {
+  align-items: center;
+  cursor: grab;
+  display: flex;
+  justify-content: center;
+  line-height: 1;
+  padding: 4px 6px;
+  position: static;
+  top: 0;
+  margin-left: 10px;
+}
+
+/*sliding panes swap rotate header direction*/
+body.plugin-sliding-panes-rotate-header
+  .workspace
+  > .mod-root
+  > .workspace-leaf
+  > .workspace-leaf-content
+  > .view-header {
+  padding: 0 !important;
+  display: flex;
+  align-items: center;
+}
+
+body.plugin-sliding-panes-rotate-header
+  .workspace
+  > .mod-root
+  > .workspace-leaf
+  > .workspace-leaf-content
+  > .view-header
+  .view-action {
+  display: flex;
+  margin: 6px 0 !important;
+}
+
+body.plugin-sliding-panes-stacking .workspace > .mod-root > .workspace-leaf,
+body.plugin-sliding-panes .workspace-split.mod-vertical > .workspace-leaf {
+  box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.1) !important;
+}
+
+/* fill title container for better visual separation */
+body.plugin-sliding-panes-rotate-header
+  .workspace
+  > .mod-root
+  > .workspace-leaf
+  > .workspace-leaf-content
+  > .view-header {
+  background-color: var(--background-primary);
+  border-right: 1px solid var(--background-modifier-border) !important;
+  border-left: 1px solid var(--background-modifier-border) !important;
+}
+
+body.plugin-sliding-panes-rotate-header.plugin-sliding-panes-header-alt
+  .workspace
+  > .mod-root
+  > .workspace-leaf
+  > .workspace-leaf-content
+  > .view-header
+  .view-header-title-container {
+  margin-top: 6px !important;
+}
+
+body.plugin-sliding-panes-rotate-header .mod-root > .workspace-leaf {
+  border-right: 1px solid var(--background-modifier-border) !important;
+}
+
+body.plugin-sliding-panes .app-container::before {
+  content: none;
+}
+
+body.plugin-sliding-panes .view-header::before,
+body.plugin-sliding-panes .workspace-leaf.mod-active .view-header::before {
+  display: none;
+}
+
+/* remove long-title-obscuring gradient in normal mode */
+body.plugin-sliding-panes-rotate-header
+  .workspace
+  > .mod-root
+  > .workspace-leaf
+  > .workspace-leaf-content
+  > .view-header
+  > .view-header-title-container::before,
+body.plugin-sliding-panes-rotate-header
+  .workspace
+  > .mod-root
+  > .workspace-leaf.mod-active
+  > .workspace-leaf-content
+  > .view-header
+  > .view-header-title-container::before {
+  content: none !important;
+}
+
+/*current note title*/
+.workspace-leaf.mod-active
+  > .workspace-leaf-content
+  > .view-header
+  .view-header-icon
+  > svg,
+.workspace-leaf.mod-active
+  > .workspace-leaf-content
+  > .view-header
+  .view-header-icon:after {
+  color: var(--text-normal);
+}
+
+/*no highlighting of current workspace leaf*/
+body:not(.plugin-sliding-panes)
+  .workspace
+  > .mod-root
+  > .workspace-leaf.mod-active
+  > .workspace-leaf-content
+  > .view-header,
+body:not(.plugin-sliding-panes-rotate-header)
+  .workspace
+  > .mod-root
+  > .workspace-leaf.mod-active
+  > .workspace-leaf-content
+  > .view-header {
+  border-right: none;
+}
+
+.view-header,
+.workspace-leaf.mod-active .view-header,
+body:not(.plugin-sliding-panes)
+  .workspace
+  > .mod-root
+  > .workspace-leaf
+  > .workspace-leaf-content
+  > .view-header,
+body:not(.plugin-sliding-panes)
+  .workspace
+  > .mod-root
+  > .workspace-leaf.mod-active
+  > .workspace-leaf-content
+  > .view-header {
+  border-bottom: 1px solid transparent;
+  border-top: 1px solid var(--background-primary);
+}
+
+div.view-header {
+  background-color: var(--background-primary) !important;
+}
+
+/* remove view header background */
+/*.workspace-tabs div.view-header {
+  background-color: var(--background-secondary) !important;
+}*/
+
+.focus-mode div.view-header {
+  border-top: 1px solid var(--background-primary) !important;
+}
+
+.focus-mode.plugin-tabs div.view-header {
+  border-top: none !important;
+}
+
+/*remove border in sliding panes (not rotated headers)*/
+body:not(.plugin-sliding-panes-rotate-header)
+  .workspace
+  > .mod-root
+  > .workspace-leaf
+  > .workspace-leaf-content
+  > .view-header,
+body.plugin-sliding-panes:not(.plugin-sliding-panes-rotate-header)
+  .workspace
+  > .mod-root
+  > .workspace-leaf
+  > .workspace-leaf-content
+  > .view-header,
+body.plugin-sliding-panes:not(.plugin-sliding-panes-rotate-header)
+  .workspace
+  > .mod-root
+  > .workspace-leaf.mod-active
+  > .workspace-leaf-content
+  > .view-header {
+  background-color: var(--background-primary);
+  border-bottom: 1px solid transparent;
+}
+
+.workspace-leaf-content[data-type="empty"] .view-header {
+  border-bottom: none;
+}
+
+body.plugin-sliding-panes.plugin-sliding-panes-rotate-header
+  .workspace
+  > .mod-root
+  > .workspace-leaf
+  > .workspace-leaf-content
+  > .view-header {
+  border-right: solid 1px var(--background-modifier-border) !important;
+}
+
+.focus-mode .workspace {
+  background-color: var(--background-primary) !important;
+}
+
+.hider-frameless .workspace-ribbon.mod-right .workspace-ribbon-collapse-btn,
+.hider-frameless .workspace-ribbon.mod-left .workspace-ribbon-collapse-btn {
+  margin-top: 25px;
+}
+
+.hider-frameless.plugin-sliding-panes-rotate-header .view-header-icon {
+  padding-top: 8px !important;
+}
+
+.hider-frameless:not(.is-fullscreen)
+  .workspace-split.mod-left-split
+  > .workspace-tabs {
+  padding-top: 22px !important;
+}
+
+.hider-frameless.is-fullscreen
+  .workspace-split.mod-left-split
+  > .workspace-tabs,
+.hider-frameless.is-fullscreen
+  .workspace-split.mod-right-split
+  > .workspace-tabs {
+  padding-top: 2px;
+}
+
+.mod-macos.hider-frameless.hider-ribbon:not(.plugin-sliding-panes-rotate-header):not(.is-fullscreen)
+  .workspace-split.mod-left-split.is-collapsed
+  + .mod-root
+  .workspace-leaf:first-of-type
+  .view-header {
+  padding-left: 60px !important;
+}
+
+.mod-macos.hider-frameless:not(.plugin-sliding-panes-rotate-header):not(.is-fullscreen)
+  .workspace-split.mod-left-split.is-collapsed
+  + .mod-root
+  .workspace-leaf:first-of-type
+  .view-header {
+  padding-left: 34px !important;
+}
+
+body.plugin-sliding-panes-rotate-header
+  .workspace
+  > .mod-root
+  > .workspace-leaf
+  > .workspace-leaf-content
+  > .view-header
+  .view-header-icon,
+body.plugin-sliding-panes-rotate-header
+  .workspace
+  > .mod-root
+  > .workspace-leaf
+  > .workspace-leaf-content
+  > .view-header
+  .view-actions {
+  display: flex !important;
+  line-height: 1 !important;
+}
+
+body.plugin-sliding-panes-rotate-header
+  .app-container
+  .workspace
+  > .mod-root
+  > .workspace-leaf
+  > .workspace-leaf-content
+  > .view-header
+  .view-actions {
+  line-height: 1;
+  align-items: center;
+  justify-content: center;
+}
+
+body.plugin-sliding-panes-rotate-header
+  .workspace
+  > .mod-root
+  .view-header-title-container,
+body.plugin-sliding-panes-rotate-header.plugin-sliding-panes-header-alt
+  .workspace
+  > .mod-root
+  .view-header-title {
+  margin-top: 0;
+}
+
+body.plugin-sliding-panes.plugin-sliding-panes-rotate-header.hider-scroll
+  .workspace
+  > .mod-root
+  > .workspace-leaf
+  > .workspace-leaf-content
+  > .view-header
+  .view-actions {
+  padding-bottom: 4px;
+}
+
+body.plugin-sliding-panes.plugin-sliding-panes-rotate-header.hider-scroll
+  .workspace-leaf-content
+  > .view-header
+  .view-action {
+  margin-bottom: 4px;
+}
+
+body.plugin-sliding-panes.plugin-sliding-panes-rotate-header
+  .workspace-leaf-content
+  > .view-header
+  .view-action {
+  margin-bottom: 4px !important;
+  top: unset;
+}
+
+body.plugin-sliding-panes.is-fullscreen.plugin-sliding-panes-rotate-header
+  .view-header-icon {
+  padding-top: 8px;
+}
+
+body.plugin-sliding-panes.hider-frameless.hider-ribbon
+  .mod-left-split.is-collapsed
+  + div.mod-root
+  .workspace-leaf:first-of-type
+  .view-header,
+body.plugin-sliding-panes.hider-ribbon
+  .mod-left-split.is-collapsed
+  + div.mod-root
+  .workspace-leaf:first-of-type
+  .view-header {
+  padding-left: 0 !important;
+}
+
+/* or workspace-leaf:first-of-type if only padding first header under OSX icons */
+body.plugin-sliding-panes.plugin-sliding-panes-rotate-header:not(.is-fullscreen):not(.mod-windows).hider-frameless
+  .mod-left-split.is-collapsed
+  + div.mod-root
+  > .workspace-leaf:first-of-type
+  > .workspace-leaf-content
+  > .view-header,
+body.plugin-sliding-panes.plugin-sliding-panes-rotate-header:not(.is-fullscreen):not(.mod-windows)
+  .mod-left-split.is-collapsed
+  + div.mod-root
+  > .workspace-leaf:first-of-type
+  > .workspace-leaf-content
+  > .view-header {
+  transition: padding 0.1s ease;
+}
+
+/*FONT SIZE OF LEFT SIDE DOCK, FRONT MATTER IN PREVIEW & EDITOR & CALENDAR HEADER*/
+.outline,
+.outline .pane-empty,
+.outline .collapsible-item-self,
+.outline .tree-item-inner {
+  font-size: 100% !important;
+  line-height: 1.4em;
+}
+
+/*FRONT MATTER PREVIEW*/
+.frontmatter-container {
+  background-color: var(--background-primary);
+  transition: 350ms;
+  margin-bottom: 1.5em;
+}
+
+.frontmatter-container,
+.frontmatter-container .frontmatter-container-header {
+  font-size: 0.875em;
+}
+
+.frontmatter-container .frontmatter-container-header {
+  padding-bottom: 2.5px;
+  padding-top: 2.5px;
+}
+
+.frontmatter-container .frontmatter-section-aliases .frontmatter-alias {
+  border-radius: 7px !important;
+  border: 1px solid var(--background-modifier-border);
+  padding: 10px;
+  padding-bottom: 5px;
+  padding-top: 6px;
+}
+
+.frontmatter-container .frontmatter-container-header:hover {
+  color: inherit;
+}
+
+body:not(.is-mobile) .frontmatter-container .frontmatter-section-label {
+  padding-bottom: 3px;
+  padding-top: 3px;
+}
+
+.frontmatter-container .frontmatter-section {
+  margin: 1px 0;
+}
+
+.is-mobile .frontmatter-container {
+  border: unset;
+  padding: 0;
+}
+
+/*frontmatter tags*/
+
+.frontmatter-container .tag {
+  background-color: var(--tag-base);
+  border: 1px solid var(--interactive-accent);
+  font-weight: 500;
+  padding: 8px 6px !important;
+  line-height: 1em;
+  text-align: center;
+  text-decoration: none !important;
+  display: inline-block;
+  cursor: pointer;
+  border-radius: 8px;
+  transition: 0.2s ease-in-out;
+}
+
+.frontmatter-container .tag[href^="#❗️"] {
+  border: 1px solid var(--red);
+}
+
+.frontmatter-container .tag[href^="#📓"] {
+  border: 1px solid #c073ff;
+}
+
+.frontmatter-container .tag[href^="#🌱"] {
+  border: 1px solid var(--palegreen);
+}
+
+.frontmatter-container .tag[href^="#🌿"] {
+  border: 1px solid var(--palegreen);
+}
+
+.frontmatter-container .tag[href^="#🌳"] {
+  border: 1px solid var(--palegreen);
+}
+
+.frontmatter-container .tag:hover {
+  background-color: var(--tag-base);
+  border: 1px solid var(--interactive-accent);
+  color: var(--interactive-accent);
+  transition: 0.1s ease-in-out;
+}
+
+/*DROPDOWN*/
+.dropdown {
+  font-size: 0.875em;
+  color: var(--text-normal);
+  line-height: 1; /* adjust the font size in theme selection drop-down manual */
+  padding: 0.6em 1.9em 0.6em 0.8em;
+  max-width: 100%;
+  box-sizing: border-box;
+  margin: 0;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 5px;
+  -moz-appearance: rotate(90deg);
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' height='20' width='20' viewBox='0 0 20 20' focusable='false' stroke-width='px' fill='%23B9BBBE' class='dropdown-svg'%3E%3Cpath d='M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z'%3E%3C/path%3E%3C/svg%3E") !important;
+  background-color: var(--background-modifier-form-field);
+  background-repeat: no-repeat, repeat;
+  background-position: right 0.6em top 50%, 0 0;
+  background-size: 1em auto, 100%;
+  box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.05),
+    inset 0px 1px 3px rgba(255, 255, 255, 0.15);
+  transition: 100ms;
+  cursor: pointer;
+}
+
+.dropdown:hover {
+  background-color: var(--background-modifier-form-field-hover);
+}
+
+/*SEARCH INPUT*/
+
+.search-input-clear-button {
+  line-height: 2;
+  cursor: pointer;
+  top: 50%;
+  right: 5px;
+  bottom: unset;
+  height: unset;
+  width: unset;
+  margin: 0;
+  padding: 0;
+  text-align: unset;
+  vertical-align: unset;
+  align-items: center;
+  color: var(--text-faint);
+  transform: translateY(-42%);
+}
+
+.search-input-clear-button:hover {
+  color: var(--text-normal);
+}
+
+/* remove duplicate search input clear button */
+/*.search-input-clear-button:before {
+  font-size: var(--large-font-size);
+  display: block;
+}*/
+
+/* align search input clear button */
+.search-input-clear-button::after {
+  margin-top: -2px;
+  margin-right: 2pt;
+}
+
+.search-input {
+  max-width: 100%;
+  margin-left: 0;
+  width: 500px;
+}
+
+/*----------------------------------------------------------------
+DOCUMENT SEARCH
+----------------------------------------------------------------*/
+
+.document-search-container.mod-replace-mode {
+  height: unset;
+}
+
+.document-search-button,
+.document-search-close-button {
+  justify-self: flex-end;
+  top: 0;
+  font-size: 18px;
+  padding: 4px 0 4px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: auto;
+}
+
+.document-search-close-button {
+  width: 2rem;
+}
+
+.document-search-container {
+  background-color: var(--background-primary);
+  width: 100%;
+  position: absolute;
+  height: unset;
+  bottom: unset !important;
+  top: 0;
+  padding: 6px 10px;
+  border-top: 1px solid var(--background-modifier-border);
+  border-bottom: 1px solid var(--background-modifier-border);
+}
+
+input.document-search-input,
+input.document-replace-input {
+  transition: border-color 0.1s ease-in-out;
+  font-size: 13px !important;
+  height: auto;
+  margin: 0;
+  padding: 0.75em 1em 0.75em 1em;
+  line-height: 1;
+  max-width: 400px;
+}
+
+input.document-search-input:hover,
+input.document-replace-input:hover {
+  background: var(--background-primary);
+  transition: border-color 0.1s ease-in-out;
+}
+
+input.document-search-input:focus,
+input.document-replace-input:focus {
+  background: var(--background-primary);
+  transition: all 0.05s ease-in-out;
+  border: 0.25em solid var(--accent-hsl);
+}
+
+.document-search-button {
+  color: var(--text-normal);
+  font-size: 13px;
+  line-height: 1;
+  border: 1px solid transparent;
+  background-color: var(--mod-button);
+  cursor: pointer;
+  height: auto;
+  padding: 0.6em 1.2em;
+  margin: 0 0 0 5px;
+}
+
+.document-search-button:hover {
+  background-color: var(--mod-button);
+}
+
+.document-search-buttons,
+.document-replace-buttons {
+  margin-left: 5px;
+  display: flex;
+  font-size: 13px;
+  line-height: 1;
+  width: 210px;
+}
+
+.document-search,
+.document-replace {
+  height: auto;
+  overflow: visible;
+  justify-content: flex-end;
+}
+
+.document-replace {
+  padding-top: 10px;
+}
+
+/*----------------------------------------------------------------
+FILE EXPLORER
+----------------------------------------------------------------*/
+
+/* Turn off file name trimming */
+.full-file-names .tree-item-inner,
+.full-file-names .nav-file-title-content,
+.full-file-names .search-result-file-title {
+  text-overflow: unset;
+  white-space: normal;
+}
+
+.view-content {
+  padding: 0px;
+}
+
+.full-file-names .nav-file-title {
+  margin-bottom: 3px;
+}
+
+/*Text Width*/
+.nav-folder-title,
+.nav-file-title {
+  width: calc(100% - 30px);
+  border-radius: 5px !important;
+}
+
+/*Text Cut Off*/
+.nav-folder-title-content,
+.nav-file-title-content {
+  width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/*Close Off Scrolling*/
+.tree-item-self,
+.tree-item-inner,
+.search-result-file-title {
+  width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/*ATTACHMENTS IN FILE EXPLORER*/
+
+.workspace-leaf-content[data-type="file-explorer"] .nav-file-title {
+  margin-right: 10px;
+  flex-direction: row-reverse;
+}
+
+[data-type="starred"] .nav-file-title {
+  flex-direction: row;
+}
+
+.is-mobile .view-content:hover .nav-file-title.is-active div.nav-file-tag,
+.is-mobile
+  .workspace-drawer-active-tab-content:hover
+  .nav-file-title.is-active
+  div.nav-file-tag,
+.oz-explorer-container:hover
+  div.nav-file-title.oz-nav-file-title.is-active
+  span.nav-file-tag,
+.workspace-leaf-content:hover .nav-file-title.is-active div.nav-file-tag,
+.nav-file-title.is-being-dragged div.nav-file-tag {
+  border: 1px solid var(--text-on-accent);
+  color: var(--text-on-accent);
+}
+
+.nav-file-tag {
+  text-transform: lowercase;
+  text-align: center;
+  font-family: var(--font-monospace);
+  letter-spacing: 1px;
+  background-color: hsl(var(--accent-hsl), 0.25);
+  border: 1px solid transparent;
+  color: var(--background-modifier-accent);
+  font-weight: 600;
+}
+
+/*file explorer padding*/
+
+.nav-file-title,
+.nav-folder-title,
+.nav-vault-title,
+.nav-folder-title.has-folder-note {
+  padding: 1px 6px 1px 0px;
+}
+
+.nav-folder-title-content,
+.nav-file-title-content {
+  line-height: 1.5em; /* enlarge line height in file explorer */
+}
+
+.nav-folder,
+.nav-file {
+  overflow: hidden;
+  padding: 0px 0 0 10px;
+  margin-left: -2px;
+  margin-right: 1px;
+}
+
+.nav-file-title,
+.nav-folder-title,
+.nav-vault-title,
+.nav-folder-title.has-folder-note {
+  font-size: var(--small-font-size);
+  color: var(--text-muted);
+}
+
+.workspace-leaf-content[data-type="recent-files"] .nav-file {
+  margin-left: -13px;
+}
+
+/* Vault Title */
+
+.nav-folder.mod-root > .nav-folder-title .nav-folder-title-content {
+  display: none;
+  color: var(--text-muted);
+  font-size: var(--small-font-size);
+  text-transform: uppercase;
+  margin-left: -2px;
+}
+
+.nav-folder.mod-root > .nav-folder-title:hover {
+  color: none;
+  cursor: pointer;
+}
+
+/* FOLDERS & FILES */
+
+.nav-file-title.is-active,
+.workspace-leaf-content[data-type="file-explorer"]:not(:hover)
+  .nav-file-title.is-active {
+  transition: 0.3s ease-in-out;
+  color: var(--text-muted);
+  background-color: var(--background-zero);
+}
+
+.nav-file-title.is-active:hover,
+.view-content:hover .nav-file-title.is-active,
+.workspace-split.mod-left-split .view-content:hover .nav-file-title.is-active,
+.workspace-split.mod-right-split .view-content:hover .nav-file-title.is-active,
+.workspace-leaf-content[data-type="file-explorer"]:hover
+  .nav-file-title.is-active {
+  transition: 0.3s ease-in-out;
+  color: var(--text-on-accent) !important;
+  background-color: var(--interactive-accent-hover) !important;
+}
+
+.nav-file-title.is-being-dragged,
+.nav-folder-title.is-being-dragged {
+  background-color: var(--interactive-accent-hover);
+}
+
+.nav-file-title.is-being-dragged-over, /*comeback*/
+.nav-folder-title.is-being-dragged-over {
+  background-color: var(--interactive-accent-hover);
+  color: var(--text-on-accent);
+}
+
+.nav-folder-title-content.is-being-renamed,
+.nav-file-title-content.is-being-renamed {
+  color: var(--text-muted);
+}
+
+.nav-folder-title.is-being-dragged-over svg.right-triangle,
+.nav-folder-title.is-being-dragged-over .collapse-icon::before,
+.nav-folder-title.is-being-dragged-over .is-collapsed .collapse-icon::before {
+  color: var(--text-on-accent) !important;
+  fill: var(--text-on-accent) !important;
+}
+
+.nav-folder-title .collapse-icon::before,
+.nav-folder-title:hover .collapse-icon::before,
+.nav-folder:hover .collapse-icon:before {
+  color: var(--text-faint);
+}
+
+.nav-file-title:not(.is-active):hover,
+.nav-folder-title:hover {
+  background-color: unset !important;
+  color: var(--text-muted) !important;
+}
+
+/*STARRED PANE*/
+
+.item-list {
+  padding: 1px 0 0 0px;
+}
+
+.item-list .nav-file {
+  margin-left: 5px;
+  padding: 0px 10px 0 10px;
+}
+
+/*BACKLINK PANE*/
+.backlink-pane .search-result-file-title {
+  vertical-align: middle;
+  padding-left: 25px;
+  padding-right: 5px;
+  font-weight: 500;
+  /*padding: 0px 5px 0px 25px;*/
+}
+
+.backlink-pane {
+  overflow-x: hidden;
+  padding-left: 15px;
+  padding-right: 5px;
+  line-height: 1.75;
+}
+
+/*OUTGOING LINK PANE*/
+.outgoing-link-pane {
+  overflow-x: hidden;
+  padding-left: 10px;
+  padding-right: 5px;
+  line-height: 1.75;
+}
+
+.search-empty-state {
+  padding: 0 0 0 15px;
+  font-size: 0.875em !important;
+  width: 100%;
+}
+
+.search-result-file-match-replace-button {
+  text-align: center;
+  font-size: 15px;
+  border: 1px solid var(--background-modifier-border);
+  color: var(--text-on-accent);
+  padding: 7.5px 12px;
+}
+
+/* --------------- */
+/* OUTLINE  PANE*/
+
+.outline {
+  padding: 10px 10px 5rem;
+}
+.outline .pane-empty {
+  padding: 0 0 0 15px;
+  width: 100%;
+}
+
+.outline .tree-item-self {
+  font-weight: 500;
+  display: flex;
+  align-items: flex-start;
+  line-height: 1;
+  padding: 0;
+  margin: 0;
+}
+
+.outline .tree-item-self .tree-item-icon {
+  padding-right: 0px !important;
+}
+
+.outline .tree-item-self .collapse-icon {
+  position: relative;
+  margin-left: -2px;
+  margin-right: -3px;
+}
+.outline > .tree-item > .tree-item-self .right-triangle {
+  opacity: unset;
+}
+
+.outline .tree-item-inner {
+  align-items: flex-start;
+  position: relative;
+  padding: 5px 6px;
+  line-height: 1.4;
+}
+
+.outline .tree-item-inner::before {
+  flex-shrink: 0;
+  content: "●";
+  font-family: sans-serif;
+  display: inline-block;
+  align-items: center;
+  justify-content: center;
+  width: 12px;
+  height: 12px;
+  font-size: 10px;
+  position: relative;
+  top: -0.1em;
+  margin-right: 3px;
+}
+.outline .tree-item-inner:not(:only-child)::before {
+  display: none;
+}
+
+.outline .tree-item-self.is-clickable:hover {
+  background-color: var(--background-zero);
+  border-radius: 5px;
+}
+
+/* remove relationship lines in outline pane */
+.outline .tree-item-children {
+  /* padding-left: var(--size-4-2); */
+  padding-left: unset;
+  margin-left: var(--size-4-3);
+  margin-bottom: 1px;
+  /* border-left: var(--nav-indentation-guide-width) solid var(--nav-indentation-guide-color); */
+  border-left: unset;
+}
+
+/*tag pane*/
+.tree-item-self.is-clickable:hover .tree-item-flair,
+.tree-item:hover .tree-item-flair {
+  color: var(--text-muted);
+  transition: 150ms ease-in-out;
+}
+
+.tag-pane-tag {
+  font-size: 15px !important;
+  margin-left: 10px;
+}
+
+.tag-container .tree-item-inner {
+  line-height: 1.5em;
+}
+
+.tag-container .tree-item-self:hover,
+.outline .tree-item-self:hover {
+  transition: 0.3s ease-in-out;
+  background-color: var(--background-zero);
+}
+
+.tree-item-self:hover .tree-item-icon {
+  color: var(--text-normal) !important;
+}
+
+.tag-container .tree-item-self .outline .tree-item-self {
+  transition: 0.3s ease-in-out;
+}
+
+/* STATUS BAR*/
+
+.status-bar-item {
+  margin: 0 0 0 6px;
+  color: var(--text-muted);
+  font-size: 0.875em;
+  padding: 0;
+}
+
+.status-bar-item:first-child::before {
+  padding-right: 6px;
+  color: var(--text-normal);
+  content: "☯︎";
+  font-weight: 900;
+  font-size: 1.165em;
+  font-family: sans-serif;
+  text-align: center;
+  align-items: center;
+  justify-content: center;
+}
+
+.no-status-icon .status-bar-item::before {
+  padding-left: unset;
+  color: unset;
+  content: unset;
+  padding-bottom: unset;
+  text-align: unset;
+  align-items: unset;
+  justify-content: unset;
+  background-color: unset;
+  -webkit-mask-image: unset;
+}
+
+.status-bar-item {
+  cursor: pointer;
+}
+
+.status-bar {
+  background-color: var(--background-secondary-alt);
+  margin: 0 0px !important;
+}
+
+.status-bar-item-icon svg {
+  display: block;
+  width: 1em;
+  height: 1em;
+  fill: currentColor;
+}
+
+.status-bar,
+.is-translucent .status-bar {
+  border: 1px solid var(--background-modifier-border) !important;
+  background-color: var(--background-secondary);
+  position: absolute;
+  margin: auto;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  border-top-left-radius: 8px;
+  line-height: 1;
+  padding: 8px 12px 6px 12px;
+  color: var(--text-normal);
+  max-height: unset;
+}
+
+.is-translucent .status-bar {
+  border: 1px solid var(--background-modifier-border);
+}
+
+.is-translucent .status-bar:hover {
+  opacity: 0.9;
+}
+
+.status-bar,
+.is-translucent .status-bar {
+  opacity: 0;
+  transition: 200ms;
+}
+
+.status-bar:hover {
+  opacity: 1;
+  transition: 200ms;
+}
+
+body .lt-predictions-container {
+  font-family: var(--default-font);
+  border: 1px solid var(--background-modifier-border);
+}
+
+body .lt-buttoncontainer > button {
+  font-weight: 500;
+  color: var(--text-normal);
+  padding: 4px 14px;
+  background: var(--mod-button);
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.08);
+}
+
+body .lt-title:not(:empty) {
+  font-weight: 500;
+}
+
+body .lt-status-bar-btn svg {
+  width: 12px;
+  height: 12px;
+}
+
+.lt-ignore-btn > span {
+  font-size: 14px;
+  line-height: 1.25em;
+}
+
+body .lt-ignore-btn {
+  background-color: var(--background-secondary);
+  font-weight: 500;
+  color: var(--text-muted);
+  transition: 100ms color, 250ms background-color;
+}
+
+body .lt-ignore-btn:hover {
+  background-color: var(--background-modifier-border);
+  color: var(--text-normal);
+}
+
+.theme-dark body .lt-ignore-btn:hover {
+  background-color: var(--background-primary-alt);
+}
+
+.day-planner-progress-bar {
+  margin: -4px 0 !important;
+  top: 5px !important;
+}
+
+.progress-pie.day-planner {
+  margin: -2px 4px !important;
+}
+
+body:not(.persistent-sb) .status-bar,
+body:not(.persistent-sb) .is-translucent .status-bar,
+body:not(.persistent-sb) .is-translucent .status-bar:hover {
+  opacity: 1;
+  border: 1px solid var(--background-modifier-morder);
+  background-color: var(--background-secondary);
+}
+
+/*ICONS*/
+
+/*ICONS colors*/
+
+.nav-action-button.is-active {
+  box-shadow: 0px 0px 1px 1px inset var(--background-tertiary);
+  background-color: var(--background-primary);
+  color: var(--text-muted);
+}
+
+.theme-dark .nav-action-button.is-active {
+  box-shadow: 0px 0px 0px 1px inset var(--background-tertiary);
+}
+
+.nav-action-button.is-active:hover {
+  color: var(--text-normal);
+}
+
+.view-header-icon > svg.document {
+  width: 18px;
+  height: 18px;
+}
+
+.view-header-icon > svg,
+.view-header-icon,
+.nav-action-button {
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.workspace-tab-header,
+.side-dock-ribbon-action,
+.side-dock-ribbon-tab > svg,
+.side-dock-ribbon-tab,
+.view-header-icon,
+.workspace-ribbon-collapse-btn,
+.side-dock-ribbon-action .is-active,
+.side-dock-collapse-btn {
+  color: var(--svg-faint);
+  cursor: pointer;
+}
+
+.titlebar-button:hover,
+.view-header-icon > svg:hover,
+.nav-action-button:hover,
+.workspace-tab-header:hover,
+.side-dock-ribbon-action:hover,
+.side-dock-ribbon-action > svg:hover,
+.side-dock-ribbon-tab > svg:hover,
+.side-dock-ribbon-tab:hover,
+.view-header-icon:hover,
+.workspace-ribbon-collapse-btn:hover,
+.side-dock-ribbon-action .is-active:hover,
+.side-dock-collapse-btn:hover {
+  color: var(--interactive-accent);
+  fill: var(--interactive-accent);
+}
+
+/*FILE EXPLORER ICONS*/
+
+/* remove relationship lines in file explorer */
+.nav-folder.mod-root .nav-folder > .nav-folder-children {
+  padding-left: var(--size-4-2);
+  margin: 0 0 0 0;
+  border-left: unset;
+}
+
+.fx-rel-lines .theme-light .nav-folder-children .nav-folder-children {
+  border-left: 1px solid var(--background-tertiary);
+}
+
+.fx-rel-lines .nav-folder-children .nav-folder-children {
+  margin-left: 12px;
+  padding-left: 0;
+  border-left: 1px solid var(--background-modifier-border);
+  transition: all 0.5s ease-in-out;
+}
+
+.fx-rel-lines .nav-folder-children .nav-folder-children:hover {
+  border-left-color: var(--background-modifier-accent);
+}
+
+body:not(.no-svg-replace) .nav-file-title-content:before {
+  content: "☐";
+  font-family: sans-serif;
+  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+body:not(.no-svg-replace) .nav-file-title-content:only-child:before,
+body:not(.no-svg-replace) .search-result-collapse-indicator + span:before {
+  background-color: currentColor;
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M19.903 8.586a.997.997 0 0 0-.196-.293l-6-6a.997.997 0 0 0-.293-.196c-.03-.014-.062-.022-.094-.033a.991.991 0 0 0-.259-.051C13.04 2.011 13.021 2 13 2H6c-1.103 0-2 .897-2 2v16c0 1.103.897 2 2 2h12c1.103 0 2-.897 2-2V9c0-.021-.011-.04-.013-.062a.952.952 0 0 0-.051-.259c-.01-.032-.019-.063-.033-.093zM16.586 8H14V5.414L16.586 8zM6 20V4h6v5a1 1 0 0 0 1 1h5l.002 10H6z"/><path fill="red" d="M8 12h8v2H8zm0 4h8v2H8zm0-8h2v2H8z"></path></svg>');
+}
+
+/*File icon for notes (fixes recent files pane)*/
+body:not(.no-svg-replace)
+  .nav-folder-children
+  .nav-file-title-content:first-child::before {
+  background-color: currentColor;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M19.903 8.586a.997.997 0 0 0-.196-.293l-6-6a.997.997 0 0 0-.293-.196c-.03-.014-.062-.022-.094-.033a.991.991 0 0 0-.259-.051C13.04 2.011 13.021 2 13 2H6c-1.103 0-2 .897-2 2v16c0 1.103.897 2 2 2h12c1.103 0 2-.897 2-2V9c0-.021-.011-.04-.013-.062a.952.952 0 0 0-.051-.259c-.01-.032-.019-.063-.033-.093zM16.586 8H14V5.414L16.586 8zM6 20V4h6v5a1 1 0 0 0 1 1h5l.002 10H6z"/><path fill="red" d="M8 12h8v2H8zm0 4h8v2H8zm0-8h2v2H8z"></path></svg>');
+  font-size: calc(var(--large-font-size) + 4px);
+  display: inline-block;
+  vertical-align: -0.075em;
+  margin-right: 8px;
+  margin-left: 0px;
+}
+
+body:not(.no-svg-replace) .nav-file-title-content:before {
+  background-color: currentColor;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M6 2a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8l-6-6h-3v2H9v2h2v2H9v2h2v8H7v-6h2v-2H7V8h2V6H7V4h2V2H6zm7 2l5 5h-5V4z"/><path fill="red" d="M8 15h2v2H8z"></path></svg>');
+  font-size: calc(var(--large-font-size) + 4px);
+  display: inline-block;
+  vertical-align: -0.075em;
+  margin-right: 8px;
+  margin-left: 0px;
+}
+
+[data-type="starred"] .nav-file-title-content:before {
+  -webkit-mask-image: none !important;
+  content: none !important;
+}
+
+body:not(.no-svg-replace)
+  .nav-file-title:is([data-path$="ogv"], [data-path$="webm"], [data-path$="mp4"], [data-path$="mov"])
+  .nav-file-title-content:before {
+  background-color: currentColor;
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M19 3H5c-1.103 0-2 .897-2 2v14c0 1.103.897 2 2 2h14c1.103 0 2-.897 2-2V5c0-1.103-.897-2-2-2zM9 11V5h6v6H9zm6 2v6H9v-6h6zM5 5h2v2H5V5zm0 4h2v2H5V9zm0 4h2v2H5v-2zm0 4h2v2H5v-2zm14.002 2H17v-2h2.002v2zm-.001-4H17v-2h2.001v2zm0-4H17V9h2.001v2zM17 7V5h2v2h-2z"></path></svg>');
+}
+
+body:not(.no-svg-replace)
+  .nav-file-title:is([data-path$="3gp"], [data-path$="flac"], [data-path$="m4a"], [data-path$="ogg"], [data-path$="wav"], [data-path$="webm"], [data-path$="mp3"])
+  .nav-file-title-content:before {
+  background-color: currentColor;
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M10 7.22L6.603 10H3v4h3.603L10 16.78V7.22zM5.889 16H2a1 1 0 0 1-1-1V9a1 1 0 0 1 1-1h3.889l5.294-4.332a.5.5 0 0 1 .817.387v15.89a.5.5 0 0 1-.817.387L5.89 16zm13.517 4.134l-1.416-1.416A8.978 8.978 0 0 0 21 12a8.982 8.982 0 0 0-3.304-6.968l1.42-1.42A10.976 10.976 0 0 1 23 12c0 3.223-1.386 6.122-3.594 8.134zm-3.543-3.543l-1.422-1.422A3.993 3.993 0 0 0 16 12c0-1.43-.75-2.685-1.88-3.392l1.439-1.439A5.991 5.991 0 0 1 18 12c0 1.842-.83 3.49-2.137 4.591z"></path></svg>');
+}
+
+body:not(.no-svg-replace)
+  .nav-file-title:is([data-path$="txt"], [data-path$="org"])
+  .nav-file-title-content:before {
+  background-color: currentColor;
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M83.071 36.167c-0.046 -0.133 -0.083 -0.263 -0.138 -0.392c-0.204 -0.442 -0.458 -0.863 -0.817 -1.221l-25 -25c-0.358 -0.358 -0.779 -0.613 -1.221 -0.817c-0.125 -0.058 -0.258 -0.092 -0.392 -0.138c-0.35 -0.117 -0.708 -0.192 -1.079 -0.212C54.333 8.379 54.254 8.333 54.167 8.333H25C20.404 8.333 16.667 12.071 16.667 16.667v66.667c0 4.596 3.738 8.333 8.333 8.333h50c4.596 0 8.333 -3.738 8.333 -8.333V37.5c0 -0.088 -0.046 -0.167 -0.054 -0.258C83.258 36.875 83.188 36.517 83.071 36.167zM69.108 33.333H58.333V22.558L69.108 33.333zM25 83.333V16.667h25v20.833c0 2.304 1.863 4.167 4.167 4.167h20.833l0.008 41.667H25z"></path></svg>');
+}
+
+body:not(.no-svg-replace)
+  .nav-file-title[data-path$="pdf"]
+  .nav-file-title-content:before {
+  background-color: currentColor;
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2m0 2v14H5V5h14m-1.1 8.5c-.3-.5-1-.7-2.2-.7c-.4 0-.8 0-1.2.1c-.3-.2-.6-.4-.8-.6c-.6-.5-1.2-1.4-1.5-2.5v-.1c.3-1.3.6-2.8 0-3.5c-.3-.1-.5-.2-.7-.2h-.2c-.4 0-.7.4-.8.7c-.4 1.3-.1 2 .2 3.2c-.2.9-.6 1.8-1 2.8c-.4.7-.7 1.3-1 1.8c-.4.2-.7.3-.9.5c-1.1.7-1.7 1.5-1.8 2v.5l.5.3c.2.2.3.2.5.2c.8 0 1.7-.9 2.9-3h.1c1-.3 2.2-.5 3.9-.7c1 .5 2.2.7 2.9.7c.4 0 .7-.1.9-.3c.2-.2.3-.4.3-.6c0-.3 0-.5-.1-.6M6.8 17.3c0-.4.5-1 1.2-1.6c.1-.1.3-.2.5-.3c-.7 1.1-1.3 1.8-1.7 1.9m4.5-10.6s0-.1.1-.1h.1c.2.2.2.5.1 1.1v.2c-.1.2-.1.5-.2.8c-.3-.9-.3-1.6-.1-2m-1.2 7.6H10c.1-.3.3-.6.5-1c.4-.8.8-1.6 1-2.3c.4.9.9 1.6 1.5 2.1c.1.1.3.2.4.3c-.9.1-2.1.4-3.3.9m7.2-.1h-.2c-.4 0-1.1-.2-1.8-.5c.1-.1.2-.1.2-.1c1.4 0 1.7.2 1.8.3l.1.1c0 .2 0 .2-.1.2z"></path></svg>');
+}
+
+body:not(.no-svg-replace)
+  .nav-file-title[data-path$="ics"]
+  .nav-file-title-content:before {
+  background-color: currentColor;
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M29.167 45.833H37.5V54.167H29.167zM29.167 62.5H37.5V70.833H29.167zM45.833 45.833H54.167V54.167H45.833zM45.833 62.5H54.167V70.833H45.833zM62.5 45.833H70.833V54.167H62.5zM62.5 62.5H70.833V70.833H62.5z M20.833 91.667h58.333c4.596 0 8.333 -3.738 8.333 -8.333V33.333V25c0 -4.596 -3.738 -8.333 -8.333 -8.333h-8.333V8.333h-8.333v8.333H37.5V8.333H29.167v8.333H20.833C16.238 16.667 12.5 20.404 12.5 25v8.333v50C12.5 87.929 16.238 91.667 20.833 91.667zM79.167 33.333l0.004 50H20.833V33.333H79.167z"></path></svg>');
+}
+
+body:not(.no-svg-replace)
+  .nav-file-title:is([data-path$="excalidraw.md"], [data-path$="excalidraw"])
+  .nav-file-title-content:before {
+  background-color: currentColor;
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M20 13.998c-.092.065-2 2.083-2 3.5c0 1.494.949 2.448 2 2.5c.906.044 2-.891 2-2.5c0-1.5-1.908-3.435-2-3.5zm-16.586-1c0 .534.208 1.036.586 1.414l5.586 5.586c.378.378.88.586 1.414.586s1.036-.208 1.414-.586l7-7l-.707-.707L11 4.584L8.707 2.291L7.293 3.705l2.293 2.293L4 11.584c-.378.378-.586.88-.586 1.414zM11 7.412l5.586 5.586L11 18.584h.001l-.001 1v-1l-5.586-5.586L11 7.412z"></path></svg>');
+}
+
+body:not(.no-svg-replace)
+  .nav-file-title:is([data-path$="bmp"], [data-path$="raw"], [data-path$="tiff"], [data-path$="gif"], [data-path$="svg"], [data-path$="jpg"], [data-path$="jpeg"], [data-path$="png"])
+  .nav-file-title-content:before {
+  background-color: currentColor;
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M37.496 39.583A6.25 6.25 0 0 1 31.246 45.833A6.25 6.25 0 0 1 24.996 39.583A6.25 6.25 0 0 1 37.496 39.583z"/><path fill="red" d="M43.746 58.333l-6.25 -8.333l-12.5 16.667h50l-18.75 -25z"/><path fill="red" d="M83.329 16.667h-66.667c-4.596 0 -8.333 3.738 -8.333 8.333v50c0 4.596 3.738 8.333 8.333 8.333h66.667c4.596 0 8.333 -3.738 8.333 -8.333V25c0 -4.596 -3.738 -8.333 -8.333 -8.333zm-66.667 58.333V25h66.667l0.008 50H16.663z"></path></svg>');
+}
+
+body:not(.no-svg-replace)
+  .nav-file-title:is([data-path$="css"], [data-path$="jsx"], [data-path$="js"], [data-path$="py"], [data-path$="xml"], [data-path$="html"], [data-path$="ts"], [data-path$="yml"])
+  .nav-file-title-content:before {
+  background-color: currentColor;
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M83.333 12.5H16.667c-4.596 0 -8.333 3.738 -8.333 8.333v58.333c0 4.596 3.738 8.333 8.333 8.333h66.667c4.596 0 8.333 -3.738 8.333 -8.333V20.833c0 -4.596 -3.738 -8.333 -8.333 -8.333zM16.667 79.167V29.167h66.667l0.008 50H16.667z"/><path fill="red" d="M38.721 38.721L23.275 54.167l15.446 15.446l5.892 -5.892L35.058 54.167l9.554 -9.554zm22.558 0l-5.892 5.892L64.942 54.167l-9.554 9.554l5.892 5.892L76.725 54.167z"></path></svg>');
+}
+
+/*workspace leaf icons*/
+
+body:not(.no-svg-replace)
+  .workspace-leaf-content[data-type="video"]
+  .view-header
+  .view-header-icon
+  svg.document {
+  background-color: currentColor;
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M19 3H5c-1.103 0-2 .897-2 2v14c0 1.103.897 2 2 2h14c1.103 0 2-.897 2-2V5c0-1.103-.897-2-2-2zM9 11V5h6v6H9zm6 2v6H9v-6h6zM5 5h2v2H5V5zm0 4h2v2H5V9zm0 4h2v2H5v-2zm0 4h2v2H5v-2zm14.002 2H17v-2h2.002v2zm-.001-4H17v-2h2.001v2zm0-4H17V9h2.001v2zM17 7V5h2v2h-2z"></path></svg>');
+}
+
+body:not(.no-svg-replace)
+  .workspace-leaf-content[data-type="markdown"]
+  .view-header
+  .view-header-icon
+  svg.document {
+  background-color: currentColor;
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M19.903 8.586a.997.997 0 0 0-.196-.293l-6-6a.997.997 0 0 0-.293-.196c-.03-.014-.062-.022-.094-.033a.991.991 0 0 0-.259-.051C13.04 2.011 13.021 2 13 2H6c-1.103 0-2 .897-2 2v16c0 1.103.897 2 2 2h12c1.103 0 2-.897 2-2V9c0-.021-.011-.04-.013-.062a.952.952 0 0 0-.051-.259c-.01-.032-.019-.063-.033-.093zM16.586 8H14V5.414L16.586 8zM6 20V4h6v5a1 1 0 0 0 1 1h5l.002 10H6z"/><path fill="red" d="M8 12h8v2H8zm0 4h8v2H8zm0-8h2v2H8z"></path></svg>');
+}
+
+body:not(.no-svg-replace)
+  .workspace-leaf-content[data-type="audio"]
+  .view-header
+  .view-header-icon
+  > svg {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M10 7.22L6.603 10H3v4h3.603L10 16.78V7.22zM5.889 16H2a1 1 0 0 1-1-1V9a1 1 0 0 1 1-1h3.889l5.294-4.332a.5.5 0 0 1 .817.387v15.89a.5.5 0 0 1-.817.387L5.89 16zm13.517 4.134l-1.416-1.416A8.978 8.978 0 0 0 21 12a8.982 8.982 0 0 0-3.304-6.968l1.42-1.42A10.976 10.976 0 0 1 23 12c0 3.223-1.386 6.122-3.594 8.134zm-3.543-3.543l-1.422-1.422A3.993 3.993 0 0 0 16 12c0-1.43-.75-2.685-1.88-3.392l1.439-1.439A5.991 5.991 0 0 1 18 12c0 1.842-.83 3.49-2.137 4.591z"></path></svg>');
+}
+body:not(.no-svg-replace)
+  .workspace-leaf-content[data-type="image"]
+  .view-header
+  .view-header-icon
+  > svg {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M37.496 39.583A6.25 6.25 0 0 1 31.246 45.833A6.25 6.25 0 0 1 24.996 39.583A6.25 6.25 0 0 1 37.496 39.583z"/><path fill="red" d="M43.746 58.333l-6.25 -8.333l-12.5 16.667h50l-18.75 -25z"/><path fill="red" d="M83.329 16.667h-66.667c-4.596 0 -8.333 3.738 -8.333 8.333v50c0 4.596 3.738 8.333 8.333 8.333h66.667c4.596 0 8.333 -3.738 8.333 -8.333V25c0 -4.596 -3.738 -8.333 -8.333 -8.333zm-66.667 58.333V25h66.667l0.008 50H16.663z"></path></svg>');
+}
+body:not(.no-svg-replace)
+  .workspace-leaf-content[data-type="video"]
+  .view-header
+  .view-header-icon
+  > svg {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M19 3H5c-1.103 0-2 .897-2 2v14c0 1.103.897 2 2 2h14c1.103 0 2-.897 2-2V5c0-1.103-.897-2-2-2zM9 11V5h6v6H9zm6 2v6H9v-6h6zM5 5h2v2H5V5zm0 4h2v2H5V9zm0 4h2v2H5v-2zm0 4h2v2H5v-2zm14.002 2H17v-2h2.002v2zm-.001-4H17v-2h2.001v2zm0-4H17V9h2.001v2zM17 7V5h2v2h-2z"></path></svg>');
+}
+body:not(.no-svg-replace)
+  .workspace-leaf-content[data-type="excalidraw"]
+  .view-header
+  .view-header-icon
+  > svg {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M20 13.998c-.092.065-2 2.083-2 3.5c0 1.494.949 2.448 2 2.5c.906.044 2-.891 2-2.5c0-1.5-1.908-3.435-2-3.5zm-16.586-1c0 .534.208 1.036.586 1.414l5.586 5.586c.378.378.88.586 1.414.586s1.036-.208 1.414-.586l7-7l-.707-.707L11 4.584L8.707 2.291L7.293 3.705l2.293 2.293L4 11.584c-.378.378-.586.88-.586 1.414zM11 7.412l5.586 5.586L11 18.584h.001l-.001 1v-1l-5.586-5.586L11 7.412z"></path></svg>');
+}
+body:not(.no-svg-replace)
+  .workspace-leaf-content[data-type="markdown"]
+  .view-header
+  .view-header-icon
+  > svg {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M19.903 8.586a.997.997 0 0 0-.196-.293l-6-6a.997.997 0 0 0-.293-.196c-.03-.014-.062-.022-.094-.033a.991.991 0 0 0-.259-.051C13.04 2.011 13.021 2 13 2H6c-1.103 0-2 .897-2 2v16c0 1.103.897 2 2 2h12c1.103 0 2-.897 2-2V9c0-.021-.011-.04-.013-.062a.952.952 0 0 0-.051-.259c-.01-.032-.019-.063-.033-.093zM16.586 8H14V5.414L16.586 8zM6 20V4h6v5a1 1 0 0 0 1 1h5l.002 10H6z"/><path fill="red" d="M8 12h8v2H8zm0 4h8v2H8zm0-8h2v2H8z"></path></svg>');
+}
+body:not(.no-svg-replace)
+  .workspace-leaf-content[data-type="kanban"]
+  .view-header
+  .view-header-icon
+  > svg {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M10 3H4a1 1 0 0 0-1 1v6a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4a1 1 0 0 0-1-1zM9 9H5V5h4v4zm11 4h-6a1 1 0 0 0-1 1v6a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1v-6a1 1 0 0 0-1-1zm-1 6h-4v-4h4v4zM17 3c-2.206 0-4 1.794-4 4s1.794 4 4 4s4-1.794 4-4s-1.794-4-4-4zm0 6c-1.103 0-2-.897-2-2s.897-2 2-2s2 .897 2 2s-.897 2-2 2zM7 13c-2.206 0-4 1.794-4 4s1.794 4 4 4s4-1.794 4-4s-1.794-4-4-4zm0 6c-1.103 0-2-.897-2-2s.897-2 2-2s2 .897 2 2s-.897 2-2 2z"></path></svg>');
+}
+
+/*link icons*/
+
+body:not(.no-svg-replace) .file-embed-link svg.link,
+body:not(.no-svg-replace) .markdown-embed-link svg.link {
+  height: 16px;
+  width: 16px;
+  margin-top: 0.5px;
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M54.417 33.792l5.896 5.896a29.167 29.167 0 0 1 0 41.25l-1.475 1.471a29.167 29.167 0 0 1 -41.25 -41.25l5.896 5.896a20.833 20.833 0 1 0 29.463 29.463l1.475 -1.475a20.833 20.833 0 0 0 0 -29.458l-5.896 -5.896l5.896 -5.892zm27.992 25.046l-5.892 -5.892a20.833 20.833 0 1 0 -29.463 -29.463l-1.475 1.475a20.833 20.833 0 0 0 0 29.458l5.896 5.896l-5.896 5.892l-5.892 -5.892a29.167 29.167 0 0 1 0 -41.25l1.475 -1.471a29.167 29.167 0 0 1 41.25 41.25z"></path></svg>');
+}
+
+body:not(.no-svg-replace) .external-link {
+  background: none;
+  padding-right: 0;
+}
+
+body:not(.no-svg-replace) .external-link::after {
+  content: " ";
+  display: inline-block;
+  width: 0.8em;
+  height: 0.8em;
+  margin-left: 4px;
+  padding-left: 1px;
+  background-color: var(--interactive-accent);
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="slategrey" d="M13 3l3.293 3.293l-7 7l1.414 1.414l7-7L21 11V3z"/><path fill="slategrey" d="M19 19H5V5h7l-2-2H5c-1.103 0-2 .897-2 2v14c0 1.103.897 2 2 2h14c1.103 0 2-.897 2-2v-5l-2-2v7z"></path></svg>');
+}
+
+/*settings modal icons*/
+
+body:not(.no-svg-replace)
+  .setting-item-control
+  button[aria-label="Edit"]
+  svg.pencil,
+body:not(.no-svg-replace)
+  .setting-editor-extra-setting-button[aria-label="Edit"]
+  svg.pencil {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M20.005 5.995h-1v2h1v8h-1v2h1c1.103 0 2-.897 2-2v-8c0-1.102-.898-2-2-2zm-14 4H15v4H6.005z"/><path fill="red" d="M17.005 17.995V4H20V2h-8v2h3.005v1.995h-11c-1.103 0-2 .897-2 2v8c0 1.103.897 2 2 2h11V20H12v2h8v-2h-2.995v-2.005zm-13-2v-8h11v8h-11z"></path></svg>');
+}
+
+body:not(.no-svg-replace)
+  .setting-hotkey-icon.setting-delete-hotkey[aria-label^="Delete hotkey"] {
+  margin-left: 7.5px;
+}
+
+body:not(.no-svg-replace)
+  .setting-hotkey-icon.setting-delete-hotkey[aria-label^="Delete hotkey"]
+  svg {
+  height: 14px;
+  width: 14px;
+  vertical-align: -0.15em;
+}
+
+body:not(.no-svg-replace)
+  .clickable-icon[aria-label^="Open "]:hover
+  svg.folder {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M6.1 10L4 18V8h17a2 2 0 0 0-2-2h-7l-2-2H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h15c.9 0 1.7-.6 1.9-1.5l2.3-8.5H6.1M19 18H6l1.6-6h13L19 18z"></path></svg>');
+}
+
+/*"close" icons*/
+
+body:not(.no-svg-replace) .modal-close-button:before,
+body:not(.no-svg-replace) .document-search-close-button:before {
+  content: " ";
+}
+
+body:not(.no-svg-replace) .modal-close-button {
+  width: 22px;
+  height: 22px;
+  background-color: currentColor;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M16.192 6.344l-4.243 4.242l-4.242-4.242l-1.414 1.414L10.535 12l-4.242 4.242l1.414 1.414l4.242-4.242l4.243 4.242l1.414-1.414L13.364 12l4.242-4.242z"></path></svg>');
+}
+
+body:not(.no-svg-replace) .document-search-close-button:before {
+  width: 22px;
+  height: 22px;
+  background-color: currentColor;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M9.172 16.242L12 13.414l2.828 2.828l1.414-1.414L13.414 12l2.828-2.828l-1.414-1.414L12 10.586L9.172 7.758L7.758 9.172L10.586 12l-2.828 2.828z"/><path fill="red" d="M12 22c5.514 0 10-4.486 10-10S17.514 2 12 2S2 6.486 2 12s4.486 10 10 10zm0-18c4.411 0 8 3.589 8 8s-3.589 8-8 8s-8-3.589-8-8s3.589-8 8-8z"></path></svg>');
+}
+
+/* remove duplicate search input clear button */
+/*body:not(.no-svg-replace) .search-input-clear-button:before {
+  width: 17px;
+  height: 17px;
+  content: " ";
+  margin-top: -2px;
+  background-color: currentColor;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M9.172 16.242L12 13.414l2.828 2.828l1.414-1.414L13.414 12l2.828-2.828l-1.414-1.414L12 10.586L9.172 7.758L7.758 9.172L10.586 12l-2.828 2.828z"/><path fill="red" d="M12 22c5.514 0 10-4.486 10-10S17.514 2 12 2S2 6.486 2 12s4.486 10 10 10zm0-18c4.411 0 8 3.589 8 8s-3.589 8-8 8s-8-3.589-8-8s3.589-8 8-8z"></path></svg>');
+}*/
+
+/*edit icons*/
+
+body:not(.no-svg-replace)
+  .view-action[aria-label^="Preview ("]
+  svg.lines-of-text {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M16.667 66.667h66.667V20.833H16.667v45.833zm37.5 8.333v8.333h16.667v8.333H29.167v-8.333h16.667v-8.333H12.467A4.158 4.158 0 0 1 8.333 70.804V16.696C8.333 14.379 10.229 12.5 12.467 12.5h75.067c2.283 0 4.133 1.871 4.133 4.196v54.108c0 2.317 -1.896 4.196 -4.133 4.196H54.167z"></path></svg>');
+}
+
+body:not(.no-svg-replace) .menu-item-icon svg.pencil,
+body:not(.no-svg-replace) .view-action[aria-label^="Edit ("] svg.pencil {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M20.005 5.995h-1v2h1v8h-1v2h1c1.103 0 2-.897 2-2v-8c0-1.102-.898-2-2-2zm-14 4H15v4H6.005z"/><path fill="red" d="M17.005 17.995V4H20V2h-8v2h3.005v1.995h-11c-1.103 0-2 .897-2 2v8c0 1.103.897 2 2 2h11V20H12v2h8v-2h-2.995v-2.005zm-13-2v-8h11v8h-11z"></path></svg>');
+}
+
+body:not(.no-svg-replace)
+  .view-action[aria-label="More options"]
+  svg.vertical-three-dots {
+  transform: rotate(90deg);
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M50 41.667c-4.583 0 -8.333 3.75 -8.333 8.333s3.75 8.333 8.333 8.333s8.333 -3.75 8.333 -8.333s-3.75 -8.333 -8.333 -8.333zm0 -25c-4.583 0 -8.333 3.75 -8.333 8.333s3.75 8.333 8.333 8.333s8.333 -3.75 8.333 -8.333s-3.75 -8.333 -8.333 -8.333zm0 50c-4.583 0 -8.333 3.75 -8.333 8.333s3.75 8.333 8.333 8.333s8.333 -3.75 8.333 -8.333s-3.75 -8.333 -8.333 -8.333z"></path></svg>');
+}
+
+/*workspace tab icons*/
+
+body:not(.no-svg-replace)
+  .workspace-tab-header[aria-label="File explorer"]
+  .workspace-tab-header-inner-icon
+  svg.folder {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M21.706 5.291l-2.999-2.998A.996.996 0 0 0 18 2H6a.996.996 0 0 0-.707.293L2.294 5.291A.994.994 0 0 0 2 5.999V19c0 1.103.897 2 2 2h16c1.103 0 2-.897 2-2V5.999a.994.994 0 0 0-.294-.708zM6.414 4h11.172l.999.999H5.415L6.414 4zM4 19V6.999h16L20.002 19H4z"/><path fill="red" d="M15 12H9v-2H7v4h10v-4h-2z"></path></svg>');
+}
+
+body:not(.no-svg-replace)
+  .workspace-tab-header[aria-label="Search"]
+  .workspace-tab-header-inner-icon
+  svg.search {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M57.113 9.554C56.333 8.771 55.275 8.333 54.167 8.333H25C20.404 8.333 16.667 12.071 16.667 16.667v66.667c0 4.596 3.738 8.333 8.333 8.333h50c4.596 0 8.333 -3.738 8.333 -8.333V37.5c0 -1.108 -0.438 -2.167 -1.221 -2.946L57.113 9.554zM25 16.667h27.442L75 39.225l0.008 38.225l-10.7 -10.7C65.767 64.271 66.667 61.413 66.667 58.333c0 -9.192 -7.475 -16.667 -16.667 -16.667s-16.667 7.475 -16.667 16.667s7.475 16.667 16.667 16.667c3.079 0 5.938 -0.9 8.417 -2.358L69.108 83.333H25V16.667zM50 66.667c-4.596 0 -8.333 -3.738 -8.333 -8.333s3.738 -8.333 8.333 -8.333s8.333 3.738 8.333 8.333S54.596 66.667 50 66.667z"></path></svg>');
+}
+
+body:not(.no-svg-replace)
+  .workspace-tab-header[aria-label="Day Planner Timeline"]
+  .workspace-tab-header-inner-icon
+  svg.calendar-with-checkmark {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M5 21h14c1.103 0 2-.897 2-2V5c0-1.103-.897-2-2-2H5c-1.103 0-2 .897-2 2v14c0 1.103.897 2 2 2zM5 5h14l.001 14H5V5z"/><path fill="red" d="M13.553 11.658l-4-2l-2.448 4.895l1.79.894l1.552-3.105l4 2l2.448-4.895l-1.79-.894z"></path></svg>');
+}
+
+.side-dock-ribbon-action[aria-label="Open Markdown Formatting Assistant"] svg,
+.workspace-tab-header[aria-label^="Markdown-Autocomplete"]
+  .workspace-tab-header-inner-icon:after {
+  height: 18px;
+  width: 18px;
+}
+
+body:not(.no-svg-replace)
+  .workspace-tab-header[aria-label^="Dual"]
+  .workspace-tab-header-inner-icon
+  svg.info {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M91.367 48.362c-0.842 -2.033 -2.646 -2.521 -3.867 -2.638V33.333c0 -4.596 -3.738 -8.333 -8.333 -8.333h-25V19.208c1.271 -1.142 2.083 -2.783 2.083 -4.625a6.25 6.25 0 0 0 -12.5 0c0 1.842 0.813 3.483 2.083 4.625V25H20.833c-4.596 0 -8.333 3.738 -8.333 8.333v12.488l-0.342 0.025A4.167 4.167 0 0 0 8.292 50v8.333a4.167 4.167 0 0 0 4.167 4.167H12.5v20.833c0 4.596 3.738 8.333 8.333 8.333h58.333c4.596 0 8.333 -3.738 8.333 -8.333v-20.833a4.167 4.167 0 0 0 4.167 -4.167v-8.075a4.192 4.192 0 0 0 -0.3 -1.896zM20.833 83.333V33.333h58.333l0.004 16.65L79.167 50v8.333l0.004 0.021l0.004 24.979H20.833z"/><path fill="red" d="M41.667 50A6.25 8.333 0 0 1 35.417 58.333A6.25 8.333 0 0 1 29.167 50A6.25 8.333 0 0 1 41.667 50z"/><path fill="red" d="M70.833 50A6.25 8.333 0 0 1 64.583 58.333A6.25 8.333 0 0 1 58.333 50A6.25 8.333 0 0 1 70.833 50z"/><path fill="red" d="M33.333 66.667h33.333v8.333H33.333z"></path></svg>');
+}
+
+body:not(.no-svg-replace)
+  .workspace-tab-header[aria-label="Calendar"]
+  .workspace-tab-header-inner-icon
+  svg.calendar-with-checkmark {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M7 11h2v2H7zm0 4h2v2H7zm4-4h2v2h-2zm0 4h2v2h-2zm4-4h2v2h-2zm0 4h2v2h-2z"/><path fill="red" d="M5 22h14c1.103 0 2-.897 2-2V6c0-1.103-.897-2-2-2h-2V2h-2v2H9V2H7v2H5c-1.103 0-2 .897-2 2v14c0 1.103.897 2 2 2zM19 8l.001 12H5V8h14z"></path></svg>');
+}
+
+body:not(.no-svg-replace)
+  .workspace-tab-header[aria-label^="Todo List"]
+  .workspace-tab-header-inner-icon
+  svg.checkmark {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M10.933 13.519l-2.226-2.226l-1.414 1.414l3.774 3.774l5.702-6.84l-1.538-1.282z" /><path fill="red" d="M19 3H5c-1.103 0-2 .897-2 2v14c0 1.103.897 2 2 2h14c1.103 0 2-.897 2-2V5c0-1.103-.897-2-2-2zM5 19V5h14l.002 14H5z"></path></svg>');
+}
+
+body:not(.no-svg-replace)
+  .workspace-tab-header[aria-label^="Graph view"]
+  .workspace-tab-header-inner-icon
+  svg.dot-network {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M79.167 12.5c-6.892 0 -12.5 5.608 -12.5 12.5c0 2.092 0.567 4.033 1.475 5.771l-4.65 5.425A16.567 16.567 0 0 0 54.167 33.333c-3.079 0 -5.938 0.9 -8.417 2.358L39.858 29.8A14.371 14.371 0 0 0 41.667 22.917C41.667 14.875 35.125 8.333 27.083 8.333S12.5 14.875 12.5 22.917S19.042 37.5 27.083 37.5c2.504 0 4.825 -0.692 6.883 -1.808L39.858 41.583A16.55 16.55 0 0 0 37.5 50c0 4.154 1.583 7.913 4.104 10.838l-7.05 7.05l0.104 0.104A12.342 12.342 0 0 0 29.167 66.667c-6.892 0 -12.5 5.608 -12.5 12.5s5.608 12.5 12.5 12.5s12.5 -5.608 12.5 -12.5c0 -1.983 -0.504 -3.829 -1.325 -5.492l0.104 0.104l8.142 -8.142c1.754 0.625 3.613 1.029 5.579 1.029c9.192 0 16.667 -7.475 16.667 -16.667a16.5 16.5 0 0 0 -1.829 -7.438l5.221 -6.092c1.517 0.658 3.183 1.029 4.942 1.029c6.892 0 12.5 -5.608 12.5 -12.5s-5.608 -12.5 -12.5 -12.5zM29.167 83.333a4.167 4.167 0 1 1 0 -8.333a4.167 4.167 0 0 1 0 8.333zM20.833 22.917C20.833 19.471 23.638 16.667 27.083 16.667S33.333 19.471 33.333 22.917S30.529 29.167 27.083 29.167S20.833 26.363 20.833 22.917zm33.333 35.417c-4.596 0 -8.333 -3.738 -8.333 -8.333s3.738 -8.333 8.333 -8.333s8.333 3.738 8.333 8.333s-3.738 8.333 -8.333 8.333zm25 -29.167a4.167 4.167 0 1 1 0 -8.333a4.167 4.167 0 0 1 0 8.333z"></path></svg>');
+}
+
+/*nav action button icons*/
+
+body:not(.no-svg-replace)
+  .nav-action-button[title="Group by folder containing notes with dangling links"]
+  svg.folder {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M83.333 75H16.667V33.333h66.667m0 -8.333h-33.333l-8.333 -8.333H16.667c-4.625 0 -8.333 3.708 -8.333 8.333v50a8.333 8.333 0 0 0 8.333 8.333h66.667a8.333 8.333 0 0 0 8.333 -8.333V33.333a8.333 8.333 0 0 0 -8.333 -8.333z"></path></svg>');
+}
+
+body:not(.no-svg-replace)
+  .nav-action-button[title="Group by note containing dangling link"]
+  svg.folder {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M83.071 36.167c-0.046 -0.133 -0.083 -0.263 -0.138 -0.392c-0.204 -0.442 -0.458 -0.863 -0.817 -1.221l-25 -25c-0.358 -0.358 -0.779 -0.613 -1.221 -0.817c-0.125 -0.058 -0.258 -0.092 -0.392 -0.138c-0.35 -0.117 -0.708 -0.192 -1.079 -0.212C54.333 8.379 54.254 8.333 54.167 8.333H25C20.404 8.333 16.667 12.071 16.667 16.667v66.667c0 4.596 3.738 8.333 8.333 8.333h50c4.596 0 8.333 -3.738 8.333 -8.333V37.5c0 -0.088 -0.046 -0.167 -0.054 -0.258C83.258 36.875 83.188 36.517 83.071 36.167zM69.108 33.333H58.333V22.558L69.108 33.333zM25 83.333V16.667h25v20.833c0 2.304 1.863 4.167 4.167 4.167h20.833l0.008 41.667H25z"></path></svg>');
+}
+
+body:not(.no-svg-replace)
+  .nav-action-button[title="Group by dangling link"]
+  svg.folder {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M18.364 15.536L16.95 14.12l1.414-1.414a5 5 0 1 0-7.071-7.071L9.879 7.05L8.464 5.636L9.88 4.222a7 7 0 0 1 9.9 9.9l-1.415 1.414zm-2.828 2.828l-1.415 1.414a7 7 0 0 1-9.9-9.9l1.415-1.414L7.05 9.88l-1.414 1.414a5 5 0 1 0 7.071 7.071l1.414-1.414l1.415 1.414zm-.708-10.607l1.415 1.415l-7.071 7.07l-1.415-1.414l7.071-7.07z"></path></svg>');
+}
+
+body:not(.no-svg-replace)
+  .nav-action-button[title="Change sort order"]
+  svg.folder {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="black" d="M49.792 33.125l-5.892 5.892L33.333 28.45V83.333H25V28.45L14.438 39.017L8.542 33.125L29.167 12.5l20.625 20.625zm41.667 33.75L70.833 87.5l-20.625 -20.625l5.892 -5.892l10.571 10.567L66.667 16.667h8.333v54.883l10.567 -10.567l5.892 5.892z"></path></svg>');
+}
+
+body:not(.no-svg-replace)
+  .nav-action-button[aria-label="New note"]
+  svg.document {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M54.167 29.167h-8.333v16.667H29.167v8.333h16.667v16.667h8.333v-16.667h16.667v-8.333h-16.667z M50 8.333C27.025 8.333 8.333 27.025 8.333 50s18.692 41.667 41.667 41.667s41.667 -18.692 41.667 -41.667S72.975 8.333 50 8.333zm0 75c-18.379 0 -33.333 -14.954 -33.333 -33.333s14.954 -33.333 33.333 -33.333s33.333 14.954 33.333 33.333s-14.954 33.333 -33.333 33.333z"></path></svg>');
+}
+
+body:not(.no-svg-replace)
+  .nav-action-button[aria-label="New folder"]
+  svg.folder {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M54.167 37.5L45.833 37.5 45.833 50 33.333 50 33.333 58.333 45.833 58.333 45.833 70.833 54.167 70.833 54.167 58.333 66.667 58.333 66.667 50 54.167 50z M83.333 20.833h-35.775L40.446 13.721C39.667 12.938 38.608 12.5 37.5 12.5H16.667C12.071 12.5 8.333 16.238 8.333 20.833v58.333c0 4.596 3.738 8.333 8.333 8.333h66.667c4.596 0 8.333 -3.738 8.333 -8.333V29.167C91.667 24.571 87.929 20.833 83.333 20.833zM16.667 79.167V29.167h29.167h4.167h33.333l0.008 50H16.667z"></path></svg>');
+}
+
+/*side dock ribbon icons*/
+
+body:not(.no-svg-replace)
+  .side-dock-ribbon-action[aria-label="Open graph view"]
+  svg.dot-network {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M19.5 3A2.502 2.502 0 0 0 17 5.5c0 .357.078.696.214 1.005l-1.955 2.199A3.977 3.977 0 0 0 13 8c-.74 0-1.424.216-2.019.566L8.707 6.293l-.023.023C8.88 5.918 9 5.475 9 5a3 3 0 1 0-3 3c.475 0 .917-.12 1.316-.316l-.023.023L9.567 9.98A3.956 3.956 0 0 0 9 12c0 .997.38 1.899.985 2.601l-2.577 2.576A2.472 2.472 0 0 0 6.5 17C5.122 17 4 18.121 4 19.5S5.122 22 6.5 22S9 20.879 9 19.5c0-.321-.066-.626-.177-.909l2.838-2.838c.421.15.867.247 1.339.247c2.206 0 4-1.794 4-4c0-.636-.163-1.229-.428-1.764l2.117-2.383c.256.088.526.147.811.147C20.879 8 22 6.879 22 5.5S20.879 3 19.5 3zM13 14c-1.103 0-2-.897-2-2s.897-2 2-2s2 .897 2 2s-.897 2-2 2z"></path></svg>');
+}
+
+body:not(.no-svg-replace)
+  .side-dock-ribbon-action[aria-label="Open Markdown importer"]
+  svg.blocks {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M12 18l4-5h-3V2h-2v11H8z"/><path fill="red" d="M19 9h-4v2h4v9H5v-9h4V9H5c-1.103 0-2 .897-2 2v9c0 1.103.897 2 2 2h14c1.103 0 2-.897 2-2v-9c0-1.103-.897-2-2-2z"></path></svg>');
+}
+
+body:not(.no-svg-replace)
+  .side-dock-ribbon-action[aria-label="Add to Ledger"]
+  > svg {
+  height: 16px;
+  width: 16px;
+}
+
+body:not(.no-svg-replace)
+  .side-dock-ribbon-action[aria-label="Create new Zettelkasten note"]
+  svg.sheets-in-box {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M20.005 2C21.107 2 22 2.898 22 3.99v16.02c0 1.099-.893 1.99-1.995 1.99H4v-4H2v-2h2v-3H2v-2h2V8H2V6h2V2h16.005zM8 4H6v16h2V4zm12 0H10v16h10V4z"></path></svg>');
+}
+
+body:not(.no-svg-replace)
+  .side-dock-ribbon-action[aria-label="Open random note"]
+  svg.dice {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M79.167 12.5H20.833c-4.596 0 -8.333 3.738 -8.333 8.333v58.333c0 4.596 3.738 8.333 8.333 8.333h58.333c4.596 0 8.333 -3.738 8.333 -8.333V20.833c0 -4.596 -3.738 -8.333 -8.333 -8.333zM20.833 79.167V20.833h58.333l0.008 58.333H20.833z"/><path fill="red" d="M39.583 33.333A6.25 6.25 0 0 1 33.333 39.583A6.25 6.25 0 0 1 27.083 33.333A6.25 6.25 0 0 1 39.583 33.333z"/><path fill="red" d="M56.25 50A6.25 6.25 0 0 1 50 56.25A6.25 6.25 0 0 1 43.75 50A6.25 6.25 0 0 1 56.25 50z"/><path fill="red" d="M72.917 66.667A6.25 6.25 0 0 1 66.667 72.917A6.25 6.25 0 0 1 60.417 66.667A6.25 6.25 0 0 1 72.917 66.667z"/><path fill="red" d="M39.583 66.667A6.25 6.25 0 0 1 33.333 72.917A6.25 6.25 0 0 1 27.083 66.667A6.25 6.25 0 0 1 39.583 66.667z"/><path fill="red" d="M72.917 33.333A6.25 6.25 0 0 1 66.667 39.583A6.25 6.25 0 0 1 60.417 33.333A6.25 6.25 0 0 1 72.917 33.333z"></path></svg>');
+}
+
+/*comeback*/
+body:not(.no-svg-replace):not(.is-mobile)
+  .side-dock-ribbon-action[aria-label^="Toggle Focus Mode "]
+  svg.enter {
+  height: 18px;
+  width: 18px;
+}
+
+/*starred*/
+
+body:not(.no-svg-replace)
+  .workspace-leaf-content[data-type="starred"]
+  svg.document {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M19.903 8.586a.997.997 0 0 0-.196-.293l-6-6a.997.997 0 0 0-.293-.196c-.03-.014-.062-.022-.094-.033a.991.991 0 0 0-.259-.051C13.04 2.011 13.021 2 13 2H6c-1.103 0-2 .897-2 2v16c0 1.103.897 2 2 2h12c1.103 0 2-.897 2-2V9c0-.021-.011-.04-.013-.062a.952.952 0 0 0-.051-.259c-.01-.032-.019-.063-.033-.093zM16.586 8H14V5.414L16.586 8zM6 20V4h6v5a1 1 0 0 0 1 1h5l.002 10H6z"/><path fill="red" d="M8 12h8v2H8zm0 4h8v2H8zm0-8h2v2H8z"></path></svg>');
+}
+
+body:not(.no-svg-replace)
+  .workspace-leaf-content[data-type="starred"]
+  svg.search {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M57.113 9.554C56.333 8.771 55.275 8.333 54.167 8.333H25C20.404 8.333 16.667 12.071 16.667 16.667v66.667c0 4.596 3.738 8.333 8.333 8.333h50c4.596 0 8.333 -3.738 8.333 -8.333V37.5c0 -1.108 -0.438 -2.167 -1.221 -2.946L57.113 9.554zM25 16.667h27.442L75 39.225l0.008 38.225l-10.7 -10.7C65.767 64.271 66.667 61.413 66.667 58.333c0 -9.192 -7.475 -16.667 -16.667 -16.667s-16.667 7.475 -16.667 16.667s7.475 16.667 16.667 16.667c3.079 0 5.938 -0.9 8.417 -2.358L69.108 83.333H25V16.667zM50 66.667c-4.596 0 -8.333 -3.738 -8.333 -8.333s3.738 -8.333 8.333 -8.333s8.333 3.738 8.333 8.333S54.596 66.667 50 66.667z"></path></svg>');
+}
+
+body:not(.no-svg-replace)
+  .workspace-leaf-content[data-type="starred"]
+  .nav-file-icon {
+  display: inline-block;
+  margin-right: 4px;
+  margin-left: 5px;
+  position: relative;
+  top: 2px;
+  height: 18px;
+  width: 18px;
+}
+
+body:not(.no-svg-replace)
+  .workspace-leaf-content[data-type="starred"]
+  .nav-file-icon
+  svg {
+  height: 18px;
+  width: 18px;
+}
+
+/*TAG PANE ICONS*/
+
+.tag-pane-tag {
+  padding-left: 0px;
+  padding-right: 0px;
+}
+
+.tag-pane-tag-text:before {
+  margin-left: 3px !important;
+  content: "☐";
+  background-color: currentColor;
+  text-align: center;
+  align-items: center;
+  justify-content: center;
+  background-repeat: no-repeat;
+  background-size: 18px;
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M66.742 15.896L63.467 33.333h-20.692l2.983 -15.896l-8.183 -1.542L34.3 33.333H16.667v8.333h16.071l-3.129 16.667H12.5v8.333h15.546l-2.975 15.854l8.188 1.538L36.525 66.667h20.692l-2.975 15.854l8.188 1.538l3.263 -17.392H83.333v-8.333h-16.079l3.129 -16.667H87.5V33.333h-15.554l2.983 -15.896l-8.188 -1.542zM58.775 58.333H38.088l3.129 -16.667h20.692l-3.133 16.667z"></path></svg>');
+  font-family: sans-serif;
+  font-size: 14px;
+  padding-right: 5px;
+  position: relative;
+}
+
+.tag-pane-tag > .collapse-icon + .tree-item-inner > .tag-pane-tag-text:before {
+  content: none;
+  margin-left: -5px;
+}
+
+.tag-pane-tag > div.collapse-icon {
+  top: 2px;
+  position: relative;
+  margin-left: -2px !important;
+}
+
+/*----------------------------------------------------------------
+SIDE RIBBON
+----------------------------------------------------------------*/
+
+.workspace-ribbon-collapse-btn {
+  margin-top: 10px;
+  margin-bottom: 2px;
+}
+
+.workspace-ribbon .workspace-ribbon-collapse-btn,
+.workspace-ribbon.mod-left .workspace-ribbon-collapse-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  height: unset;
+  width: unset;
+  top: unset;
+  line-height: 0;
+  padding: 8px 6px;
+  bottom: 28px;
+  z-index: 9;
+}
+
+body:not(.hider-ribbon):not(.hider-frameless)
+  .workspace-ribbon.mod-right.is-collapsed,
+body:not(.hider-ribbon):not(.hider-frameless)
+  .workspace-ribbon.mod-left.is-collapsed {
+  padding-right: 5px;
+}
+
+.workspace-ribbon.mod-right,
+.workspace-ribbon.mod-left {
+  padding: 0 0 0 5px;
+  /*position: relative;*/ /* aligned the left-side bar bottom in full screen mode */
+  flex-basis: unset;
+  flex-shrink: 0;
+  flex-grow: 0;
+}
+
+.hider-ribbon .side-dock-actions,
+.hider-ribbon .side-dock-settings {
+  display: flex;
+  background-color: transparent;
+  border-top: none;
+  margin: 0;
+}
+
+.hider-ribbon .side-dock-actions {
+  padding: 5px 0 5px 5px;
+}
+
+.hider-ribbon .workspace-ribbon.mod-left .side-dock-ribbon-action,
+.workspace-ribbon.mod-left .side-dock-ribbon-action {
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3.75px 6px;
+  margin-bottom: 5px;
+}
+
+.side-dock-ribbon {
+  border-left: 0;
+}
+
+.workspace-ribbon {
+  width: unset;
+}
+
+.side-dock-settings {
+  margin-bottom: 0px;
+  padding: 0;
+}
+
+/*----------------------------------------------------------------
+MENU ICONS
+----------------------------------------------------------------*/
+div.menu-item:hover .menu-item-icon svg,
+div.menu-item:hover .menu-item-icon svg path {
+  fill: var(--text-normal);
+  color: var(--text-normal);
+}
+
+.menu-item-icon {
+  position: static;
+  margin-right: 2px;
+}
+
+body:not(.no-svg-replace) svg.excalidraw-icon > path {
+  display: none;
+}
+
+body:not(.no-svg-replace) svg.excalidraw-icon {
+  height: 18px;
+  width: 18px;
+  background-color: currentColor;
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M20 13.998c-.092.065-2 2.083-2 3.5c0 1.494.949 2.448 2 2.5c.906.044 2-.891 2-2.5c0-1.5-1.908-3.435-2-3.5zm-16.586-1c0 .534.208 1.036.586 1.414l5.586 5.586c.378.378.88.586 1.414.586s1.036-.208 1.414-.586l7-7l-.707-.707L11 4.584L8.707 2.291L7.293 3.705l2.293 2.293L4 11.584c-.378.378-.586.88-.586 1.414zM11 7.412l5.586 5.586L11 18.584h.001l-.001 1v-1l-5.586-5.586L11 7.412z"></path></svg>');
+}
+
+/*----------------------------------------------------------------
+SVG REPLACEMENT
+----------------------------------------------------------------*/
+
+body:not(.no-svg-replace) svg.any-key,
+body:not(.no-svg-replace) svg.blocks,
+body:not(.no-svg-replace) svg.bar-graph,
+body:not(.no-svg-replace) svg.breadcrumbs-trail-icon,
+body:not(.no-svg-replace) svg.audio-file,
+body:not(.no-svg-replace) svg.bold-glyph,
+body:not(.no-svg-replace) svg.italic-glyph,
+body:not(.no-svg-replace) svg.bracket-glyph,
+body:not(.no-svg-replace) svg.broken-link,
+body:not(.no-svg-replace) svg.bullet-list-glyph,
+body:not(.no-svg-replace) svg.bullet-list,
+body:not(.no-svg-replace) svg.calendar-with-checkmark,
+body:not(.no-svg-replace) svg.check-in-circle,
+body:not(.no-svg-replace) svg.check-small,
+body:not(.no-svg-replace) svg.checkbox-glyph,
+body:not(.no-svg-replace) svg.checkmark,
+body:not(.no-svg-replace) svg.clock,
+body:not(.no-svg-replace) svg.cloud,
+body:not(.no-svg-replace) svg.code-glyph,
+body:not(.no-svg-replace) svg.create-new,
+body:not(.no-svg-replace) svg.cross-in-box,
+body:not(.no-svg-replace) svg.cross,
+body:not(.no-svg-replace) svg.crossed-star,
+body:not(.no-svg-replace) svg.dice,
+body:not(.no-svg-replace) svg.document,
+body:not(.no-svg-replace) svg.documents,
+body:not(.no-svg-replace) svg.dot-network,
+body:not(.no-svg-replace) svg.double-down-arrow-glyph,
+body:not(.no-svg-replace) svg.double-up-arrow-glyph,
+body:not(.no-svg-replace) svg.down-arrow-with-tail,
+body:not(.no-svg-replace) svg.down-chevron-glyph,
+body:not(.no-svg-replace) svg.enter,
+body:not(.no-svg-replace) svg.exit-fullscreen,
+body:not(.no-svg-replace) svg.expand-vertically,
+body:not(.no-svg-replace) svg.filled-pin,
+body:not(.no-svg-replace) svg.folder,
+body:not(.no-svg-replace) svg.fullscreen,
+body:not(.no-svg-replace) svg.gear,
+body:not(.no-svg-replace) svg.hashtag,
+body:not(.no-svg-replace) svg.heading-glyph,
+body:not(.no-svg-replace) svg.go-to-file,
+body:not(.no-svg-replace) svg.help .widget-icon,
+body:not(.no-svg-replace) svg.help,
+body:not(.no-svg-replace) svg.highlight-glyph,
+body:not(.no-svg-replace) svg.horizontal-split,
+body:not(.no-svg-replace) svg.image-file,
+body:not(.no-svg-replace) svg.image-glyph,
+body:not(.no-svg-replace) svg.indent-glyph,
+body:not(.no-svg-replace) svg.info,
+body:not(.no-svg-replace) svg.install,
+body:not(.no-svg-replace) svg.keyboard-glyph,
+body:not(.no-svg-replace) svg.left-arrow-with-tail,
+body:not(.no-svg-replace) svg.left-arrow,
+body:not(.no-svg-replace) svg.left-chevron-glyph,
+body:not(.no-svg-replace) svg.lines-of-text,
+body:not(.no-svg-replace) svg.link-glyph,
+body:not(.no-svg-replace) svg.link,
+body:not(.no-svg-replace) svg.magnifying-glass,
+body:not(.no-svg-replace) svg.microphone-filled,
+body:not(.no-svg-replace) svg.microphone,
+body:not(.no-svg-replace) svg.minus-with-circle,
+body:not(.no-svg-replace) svg.note-glyph,
+body:not(.no-svg-replace) svg.number-list-glyph,
+body:not(.no-svg-replace) svg.open-vault,
+body:not(.no-svg-replace) svg.pane-layout,
+body:not(.no-svg-replace) svg.paper-plane,
+body:not(.no-svg-replace) svg.paused,
+/*body:not(.no-svg-replace) svg.pdf-file,*/
+body:not(.no-svg-replace) svg.pencil,
+body:not(.no-svg-replace) svg.pin,
+body:not(.no-svg-replace) svg.plus-with-circle,
+body:not(.no-svg-replace) svg.popup-open,
+body:not(.no-svg-replace) svg.presentation,
+body:not(.no-svg-replace) svg.price-tag-glyph,
+body:not(.no-svg-replace) svg.quote-glyph,
+body:not(.no-svg-replace) svg.redo-glyph,
+body:not(.no-svg-replace) svg.reset,
+body:not(.no-svg-replace) svg.right-arrow-with-tail,
+body:not(.no-svg-replace) svg.right-arrow,
+body:not(.no-svg-replace) svg.right-chevron-glyph,
+body:not(.no-svg-replace) svg.right-triangle,
+body:not(.no-svg-replace) svg.run-command,
+body:not(.no-svg-replace) svg.search,
+body:not(.no-svg-replace) svg.sheets-in-box,
+body:not(.no-svg-replace) svg.spreadsheet,
+body:not(.no-svg-replace) svg.stacked-levels,
+body:not(.no-svg-replace) svg.star-list,
+body:not(.no-svg-replace) svg.star,
+body:not(.no-svg-replace) svg.strikethrough-glyph,
+body:not(.no-svg-replace) svg.switch,
+body:not(.no-svg-replace) svg.sync-small,
+body:not(.no-svg-replace) svg.sync,
+body:not(.no-svg-replace) svg.tag-glyph,
+body:not(.no-svg-replace) svg.three-horizontal-bars,
+body:not(.no-svg-replace) svg.trash,
+body:not(.no-svg-replace) svg.undo-glyph,
+body:not(.no-svg-replace) svg.unindent-glyph,
+body:not(.no-svg-replace) svg.up-and-down-arrows,
+body:not(.no-svg-replace) svg.up-arrow-with-tail,
+body:not(.no-svg-replace) svg.up-chevron-glyph,
+body:not(.no-svg-replace) svg.vault,
+body:not(.no-svg-replace) svg.vertical-split,
+body:not(.no-svg-replace) svg.vertical-three-dots,
+body:not(.no-svg-replace) svg.wrench-screwdriver-glyph,
+body:not(.no-svg-replace) svg.clock-glyph,
+/*body:not(.no-svg-replace) svg.command-glyph,*/
+body:not(.no-svg-replace) svg.add-note-glyph,
+body:not(.no-svg-replace) svg.calendar-glyph,
+body:not(.no-svg-replace) svg.duplicate-glyph,
+body:not(.no-svg-replace) svg.file-explorer-glyph,
+body:not(.no-svg-replace) svg.graph-glyph,
+body:not(.no-svg-replace) svg.import-glyph,
+body:not(.no-svg-replace) svg.languages,
+body:not(.no-svg-replace) svg.links-coming-in,
+body:not(.no-svg-replace) svg.links-going-out,
+/*body:not(.no-svg-replace) svg.merge-files-glyph,*/
+body:not(.no-svg-replace) svg.merge-files,
+body:not(.no-svg-replace) svg.open-elsewhere-glyph,
+body:not(.no-svg-replace) svg.paper-plane-glyph,
+body:not(.no-svg-replace) svg.paste-text,
+body:not(.no-svg-replace) svg.paste,
+body:not(.no-svg-replace) svg.percent-sign-glyph,
+body:not(.no-svg-replace) svg.play-audio-glyph,
+body:not(.no-svg-replace) svg.plus-minus-glyph,
+body:not(.no-svg-replace) svg.presentation-glyph,
+body:not(.no-svg-replace) svg.question-mark-glyph,
+body:not(.no-svg-replace) svg.restore-file-glyph,
+body:not(.no-svg-replace) svg.scissors-glyph,
+body:not(.no-svg-replace) svg.scissors,
+body:not(.no-svg-replace) svg.search-glyph,
+body:not(.no-svg-replace) svg.select-all-text,
+body:not(.no-svg-replace) svg.split,
+body:not(.no-svg-replace) svg.star-glyph,
+body:not(.no-svg-replace) svg.stop-audio-glyph,
+body:not(.no-svg-replace) svg.sweep,
+body:not(.no-svg-replace) svg.two-blank-pages,
+body:not(.no-svg-replace) svg.tomorrow-glyph,
+body:not(.no-svg-replace) svg.yesterday-glyph,
+body:not(.no-svg-replace) svg.workspace-glyph,
+body:not(.no-svg-replace) svg.box-glyph,
+body:not(.no-svg-replace) svg.wand,
+body:not(.no-svg-replace) svg.longform,
+body:not(.no-svg-replace) svg.changelog {
+  background-color: currentColor;
+}
+
+body:not(.no-svg-replace) svg.any-key > path,
+body:not(.no-svg-replace) svg.blocks > path,
+body:not(.no-svg-replace) svg.bar-graph > path,
+body:not(.no-svg-replace) svg.breadcrumbs-trail-icon > path,
+body:not(.no-svg-replace) svg.audio-file > path,
+body:not(.no-svg-replace) svg.bold-glyph > path,
+body:not(.no-svg-replace) svg.italic-glyph > path,
+body:not(.no-svg-replace) svg.bracket-glyph > path,
+body:not(.no-svg-replace) svg.broken-link > path,
+body:not(.no-svg-replace) svg.bullet-list-glyph > path,
+body:not(.no-svg-replace) svg.bullet-list > path,
+body:not(.no-svg-replace) svg.calendar-with-checkmark > path,
+body:not(.no-svg-replace) svg.check-in-circle > path,
+body:not(.no-svg-replace) svg.check-small > path,
+body:not(.no-svg-replace) svg.checkbox-glyph > path,
+body:not(.no-svg-replace) svg.checkmark > path,
+body:not(.no-svg-replace) svg.clock > path,
+body:not(.no-svg-replace) svg.cloud > path,
+body:not(.no-svg-replace) svg.code-glyph > path,
+body:not(.no-svg-replace) svg.create-new > path,
+body:not(.no-svg-replace) svg.cross-in-box > path,
+body:not(.no-svg-replace) svg.cross > path,
+body:not(.no-svg-replace) svg.crossed-star > path,
+body:not(.no-svg-replace) svg.dice > path,
+body:not(.no-svg-replace) svg.document > path,
+body:not(.no-svg-replace) svg.documents > path,
+body:not(.no-svg-replace) svg.dot-network > path,
+body:not(.no-svg-replace) svg.double-down-arrow-glyph > path,
+body:not(.no-svg-replace) svg.double-up-arrow-glyph > path,
+body:not(.no-svg-replace) svg.down-arrow-with-tail > path,
+body:not(.no-svg-replace) svg.down-chevron-glyph > path,
+body:not(.no-svg-replace) svg.enter > path,
+body:not(.no-svg-replace) svg.exit-fullscreen > path,
+body:not(.no-svg-replace) svg.expand-vertically > path,
+body:not(.no-svg-replace) svg.filled-pin > path,
+body:not(.no-svg-replace) svg.folder > path,
+body:not(.no-svg-replace) svg.fullscreen > path,
+body:not(.no-svg-replace) svg.gear > path,
+body:not(.no-svg-replace) svg.hashtag > path,
+body:not(.no-svg-replace) svg.heading-glyph > path,
+body:not(.no-svg-replace) svg.go-to-file > path,
+body:not(.no-svg-replace) svg.help .widget-icon > path,
+body:not(.no-svg-replace) svg.help > path,
+body:not(.no-svg-replace) svg.highlight-glyph > path,
+body:not(.no-svg-replace) svg.horizontal-split > path,
+body:not(.no-svg-replace) svg.image-file > path,
+body:not(.no-svg-replace) svg.image-glyph > path,
+body:not(.no-svg-replace) svg.indent-glyph > path,
+body:not(.no-svg-replace) svg.info > path,
+body:not(.no-svg-replace) svg.install > path,
+body:not(.no-svg-replace) svg.keyboard-glyph > path,
+body:not(.no-svg-replace) svg.left-arrow-with-tail > path,
+body:not(.no-svg-replace) svg.left-arrow > path,
+body:not(.no-svg-replace) svg.left-chevron-glyph > path,
+body:not(.no-svg-replace) svg.lines-of-text > path,
+body:not(.no-svg-replace) svg.link-glyph > path,
+body:not(.no-svg-replace) svg.link > path,
+body:not(.no-svg-replace) svg.magnifying-glass > path,
+body:not(.no-svg-replace) svg.microphone-filled > path,
+body:not(.no-svg-replace) svg.microphone > path,
+body:not(.no-svg-replace) svg.minus-with-circle > path,
+body:not(.no-svg-replace) svg.note-glyph > path,
+body:not(.no-svg-replace) svg.number-list-glyph > path,
+body:not(.no-svg-replace) svg.open-vault > path,
+body:not(.no-svg-replace) svg.pane-layout > path,
+body:not(.no-svg-replace) svg.paper-plane > path,
+body:not(.no-svg-replace) svg.paused > path,
+/*body:not(.no-svg-replace) svg.pdf-file > path,*/
+body:not(.no-svg-replace) svg.pencil > path,
+body:not(.no-svg-replace) svg.pin > path,
+body:not(.no-svg-replace) svg.plus-with-circle > path,
+body:not(.no-svg-replace) svg.popup-open > path,
+body:not(.no-svg-replace) svg.presentation > path,
+body:not(.no-svg-replace) svg.price-tag-glyph > path,
+body:not(.no-svg-replace) svg.quote-glyph > path,
+body:not(.no-svg-replace) svg.redo-glyph > path,
+body:not(.no-svg-replace) svg.reset > path,
+body:not(.no-svg-replace) svg.right-arrow-with-tail > path,
+body:not(.no-svg-replace) svg.right-arrow > path,
+body:not(.no-svg-replace) svg.right-chevron-glyph > path,
+body:not(.no-svg-replace) svg.right-triangle > path,
+body:not(.no-svg-replace) svg.run-command > path,
+body:not(.no-svg-replace) svg.search > path,
+body:not(.no-svg-replace) svg.sheets-in-box > path,
+body:not(.no-svg-replace) svg.spreadsheet > path,
+body:not(.no-svg-replace) svg.stacked-levels > path,
+body:not(.no-svg-replace) svg.star-list > path,
+body:not(.no-svg-replace) svg.star > path,
+body:not(.no-svg-replace) svg.strikethrough-glyph > path,
+body:not(.no-svg-replace) svg.switch > path,
+body:not(.no-svg-replace) svg.sync-small > path,
+body:not(.no-svg-replace) svg.sync > path,
+body:not(.no-svg-replace) svg.tag-glyph > path,
+body:not(.no-svg-replace) svg.three-horizontal-bars > path,
+body:not(.no-svg-replace) svg.trash > path,
+body:not(.no-svg-replace) svg.undo-glyph > path,
+body:not(.no-svg-replace) svg.unindent-glyph > path,
+body:not(.no-svg-replace) svg.up-and-down-arrows > path,
+body:not(.no-svg-replace) svg.up-arrow-with-tail > path,
+body:not(.no-svg-replace) svg.up-chevron-glyph > path,
+body:not(.no-svg-replace) svg.vault > path,
+body:not(.no-svg-replace) svg.vertical-split > path,
+body:not(.no-svg-replace) svg.vertical-three-dots > path,
+body:not(.no-svg-replace) svg.wrench-screwdriver-glyph > path,
+body:not(.no-svg-replace) svg.clock-glyph > path,
+/*body:not(.no-svg-replace) svg.command-glyph > path,*/
+body:not(.no-svg-replace) svg.add-note-glyph > path,
+body:not(.no-svg-replace) svg.calendar-glyph > path,
+body:not(.no-svg-replace) svg.duplicate-glyph > path,
+body:not(.no-svg-replace) svg.file-explorer-glyph > path,
+body:not(.no-svg-replace) svg.graph-glyph > path,
+body:not(.no-svg-replace) svg.import-glyph > path,
+body:not(.no-svg-replace) svg.languages > path,
+body:not(.no-svg-replace) svg.links-coming-in > path,
+body:not(.no-svg-replace) svg.links-going-out > path,
+/*body:not(.no-svg-replace) svg.merge-files-glyph > path,*/
+body:not(.no-svg-replace) svg.merge-files > path,
+body:not(.no-svg-replace) svg.open-elsewhere-glyph > path,
+body:not(.no-svg-replace) svg.paper-plane-glyph > path,
+body:not(.no-svg-replace) svg.paste-text > path,
+body:not(.no-svg-replace) svg.paste > path,
+body:not(.no-svg-replace) svg.percent-sign-glyph > path,
+body:not(.no-svg-replace) svg.play-audio-glyph > path,
+body:not(.no-svg-replace) svg.plus-minus-glyph > path,
+body:not(.no-svg-replace) svg.presentation-glyph > path,
+body:not(.no-svg-replace) svg.question-mark-glyph > path,
+body:not(.no-svg-replace) svg.restore-file-glyph > path,
+body:not(.no-svg-replace) svg.scissors-glyph > path,
+body:not(.no-svg-replace) svg.scissors > path,
+body:not(.no-svg-replace) svg.search-glyph > path,
+body:not(.no-svg-replace) svg.select-all-text > path,
+body:not(.no-svg-replace) svg.split > path,
+body:not(.no-svg-replace) svg.star-glyph > path,
+body:not(.no-svg-replace) svg.stop-audio-glyph > path,
+body:not(.no-svg-replace) svg.sweep > path,
+body:not(.no-svg-replace) svg.two-blank-pages > path,
+body:not(.no-svg-replace) svg.tomorrow-glyph > path,
+body:not(.no-svg-replace) svg.yesterday-glyph > path,
+body:not(.no-svg-replace) svg.workspace-glyph > path,
+body:not(.no-svg-replace) svg.box-glyph > path,
+body:not(.no-svg-replace) svg.wand > path,
+body:not(.no-svg-replace) svg.longform > path,
+body:not(.no-svg-replace) svg.changelog > path {
+  display: none;
+}
+
+body:not(.no-svg-replace) svg.any-key {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M27.2,8C17.7,8,10,15.7,10,25.2v37.6v14C10,86.3,17.7,94,27.2,94h45.6C82.3,94,90,86.3,90,76.8V61.2v-36 C90,15.7,82.3,8,72.8,8L27.2,8z M27.2,12h45.6C80.1,12,86,17.9,86,25.2v36v1.6C86,70.1,80.1,76,72.8,76H27.2 C19.9,76,14,70.1,14,62.8v-1.6v-36C14,17.9,19.9,12,27.2,12z M48,26v14.5L35.6,33l-2.1,3.4L46.1,44l-12.6,7.6l2.1,3.4L48,47.5V62 h4V47.5L64.4,55l2.1-3.4L53.9,44l12.6-7.6L64.4,33L52,40.5V26H48z M14,73.8c3.2,3.8,7.9,6.2,13.2,6.2h45.6c5.3,0,10-2.4,13.2-6.2 v3C86,84.1,80.1,90,72.8,90H27.2C19.9,90,14,84.1,14,76.8L14,73.8z" stroke-width="4" stroke="currentColor"></path></svg>');
+}
+body:not(.no-svg-replace) svg.audio-file {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M10 7.22L6.603 10H3v4h3.603L10 16.78V7.22zM5.889 16H2a1 1 0 0 1-1-1V9a1 1 0 0 1 1-1h3.889l5.294-4.332a.5.5 0 0 1 .817.387v15.89a.5.5 0 0 1-.817.387L5.89 16zm13.517 4.134l-1.416-1.416A8.978 8.978 0 0 0 21 12a8.982 8.982 0 0 0-3.304-6.968l1.42-1.42A10.976 10.976 0 0 1 23 12c0 3.223-1.386 6.122-3.594 8.134zm-3.543-3.543l-1.422-1.422A3.993 3.993 0 0 0 16 12c0-1.43-.75-2.685-1.88-3.392l1.439-1.439A5.991 5.991 0 0 1 18 12c0 1.842-.83 3.49-2.137 4.591z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.bar-graph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M20 7h-4V4c0-1.103-.897-2-2-2h-4c-1.103 0-2 .897-2 2v5H4c-1.103 0-2 .897-2 2v9a1 1 0 0 0 1 1h18a1 1 0 0 0 1-1V9c0-1.103-.897-2-2-2zM4 11h4v8H4v-8zm6-1V4h4v15h-4v-9zm10 9h-4V9h4v10z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.breadcrumbs-trail-icon {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M 11.742188 1.0136719 C 11.495014 0.99451258 11.245989 1.0010245 11.003906 1.0390625 C 10.519741 1.1151385 10.060171 1.3167823 9.6875 1.6894531 C 8.9427523 2.4345187 8.8811384 3.5232122 9.140625 4.4746094 C 9.4002664 5.4265742 9.9764411 6.3670666 10.804688 7.1953125 C 11.496834 7.8874596 12.264436 8.3925883 13.054688 8.6933594 C 13.05294 8.7011774 13.048573 8.708982 13.046875 8.7167969 C 12.838268 9.6768984 13.040458 10.665466 13.6875 11.3125 C 14.334556 11.959533 15.323109 12.161766 16.283203 11.953125 C 17.243297 11.744486 18.226203 11.164455 19.195312 10.195312 C 20.164421 9.2261688 20.744519 8.2433044 20.953125 7.2832031 C 21.161733 6.323102 20.959541 5.3345335 20.3125 4.6875 C 19.665444 4.0404665 18.676891 3.8382344 17.716797 4.046875 C 17.301697 4.1370811 16.88172 4.3104581 16.460938 4.5410156 C 16.1531 3.9336321 15.733191 3.3445189 15.193359 2.8046875 C 14.365195 1.9765236 13.424549 1.4022437 12.472656 1.1425781 C 12.234683 1.0776617 11.989361 1.0328312 11.742188 1.0136719 z M 11.355469 3.0039062 C 11.491174 2.9871459 11.682712 2.9981453 11.947266 3.0703125 C 12.476373 3.2146469 13.169461 3.6089139 13.779297 4.21875 C 14.292232 4.7316847 14.642645 5.2994399 14.830078 5.7832031 C 14.82185 5.7913732 14.812913 5.7964614 14.804688 5.8046875 C 14.447168 6.1622192 14.160755 6.5213226 13.908203 6.8808594 C 13.40404 6.705826 12.774737 6.3372375 12.21875 5.78125 C 11.608996 5.1714959 11.214672 4.4765508 11.070312 3.9472656 C 10.925954 3.4179805 11.025573 3.1794146 11.101562 3.1035156 C 11.139893 3.0651866 11.219764 3.0206666 11.355469 3.0039062 z M 18.443359 5.9609375 C 18.698605 5.9522653 18.825548 6.028674 18.898438 6.1015625 C 18.995628 6.1987455 19.099335 6.3912538 18.998047 6.8574219 C 18.896761 7.3235892 18.548292 8.0141814 17.78125 8.78125 C 17.014208 9.5483187 16.323586 9.896744 15.857422 9.9980469 C 15.391257 10.099351 15.198748 9.9956209 15.101562 9.8984375 C 15.004376 9.8012541 14.900665 9.6087462 15.001953 9.1425781 C 15.103239 8.6764108 15.451708 7.9858186 16.21875 7.21875 C 16.985792 6.4516813 17.676414 6.103256 18.142578 6.0019531 C 18.259119 5.9766272 18.358277 5.9638282 18.443359 5.9609375 z M 3.8886719 5.984375 C 3.1146141 5.9054734 2.2915765 6.0834024 1.6875 6.6875 C 0.8820646 7.4929634 0.83275973 8.6870674 1.1425781 9.6367188 C 1.4523965 10.58637 2.0637964 11.454448 2.8046875 12.195312 C 3.5455786 12.936179 4.4136188 13.547637 5.3632812 13.857422 C 6.3129437 14.167208 7.5070646 14.117964 8.3125 13.3125 C 9.1179353 12.507037 9.1672404 11.312932 8.8574219 10.363281 C 8.5476033 9.4136292 7.9362037 8.5455528 7.1953125 7.8046875 C 6.4544215 7.0638223 5.5863811 6.4523633 4.6367188 6.1425781 C 4.3993032 6.0651318 4.1466911 6.0106755 3.8886719 5.984375 z M 3.4335938 7.9394531 C 3.5730706 7.9266303 3.754074 7.9576494 4.015625 8.0429688 C 4.538727 8.2136077 5.2199812 8.6575008 5.78125 9.21875 C 6.3425188 9.7799991 6.7863743 10.461279 6.9570312 10.984375 C 7.1276882 11.507471 7.0852911 11.711577 6.8984375 11.898438 C 6.7115842 12.085297 6.5074768 12.127672 5.984375 11.957031 C 5.4612734 11.786394 4.7800187 11.342499 4.21875 10.78125 C 3.6574812 10.220001 3.2136258 9.5387211 3.0429688 9.015625 C 2.8723116 8.492529 2.9147092 8.2884225 3.1015625 8.1015625 C 3.1949892 8.0081325 3.2941169 7.952276 3.4335938 7.9394531 z M 17.888672 12.984375 C 17.114614 12.905473 16.291576 13.083403 15.6875 13.6875 C 14.882065 14.492963 14.83276 15.687068 15.142578 16.636719 C 15.452396 17.586371 16.063796 18.454447 16.804688 19.195312 C 17.545579 19.936177 18.413619 20.547637 19.363281 20.857422 C 20.312944 21.167208 21.507065 21.117963 22.3125 20.3125 C 23.117935 19.507037 23.16724 18.312932 22.857422 17.363281 C 22.547604 16.413629 21.936203 15.545553 21.195312 14.804688 C 20.454421 14.063823 19.586381 13.452363 18.636719 13.142578 C 18.399303 13.065132 18.146691 13.010676 17.888672 12.984375 z M 17.433594 14.939453 C 17.573071 14.926631 17.754074 14.957649 18.015625 15.042969 C 18.538728 15.213607 19.219981 15.657501 19.78125 16.21875 C 20.342519 16.779999 20.786375 17.461279 20.957031 17.984375 C 21.127688 18.507471 21.085292 18.711578 20.898438 18.898438 C 20.711583 19.085297 20.507477 19.127671 19.984375 18.957031 C 19.461272 18.786393 18.780019 18.342499 18.21875 17.78125 C 17.657481 17.220001 17.213625 16.538721 17.042969 16.015625 C 16.872312 15.492529 16.914708 15.288422 17.101562 15.101562 C 17.194989 15.008133 17.294117 14.952276 17.433594 14.939453 z M 10.435547 14.966797 C 10.197809 14.966925 9.9568203 14.994715 9.7167969 15.046875 C 8.756703 15.255514 7.7737972 15.835544 6.8046875 16.804688 C 5.8355775 17.773832 5.2554813 18.756695 5.046875 19.716797 C 4.838268 20.676897 5.0404485 21.665466 5.6875 22.3125 C 6.3345564 22.959534 7.3231095 23.161765 8.2832031 22.953125 C 9.2432974 22.744485 10.226203 22.164457 11.195312 21.195312 C 12.164421 20.226168 12.744519 19.243304 12.953125 18.283203 C 13.161733 17.323101 12.959541 16.334534 12.3125 15.6875 C 11.827208 15.202225 11.148761 14.966413 10.435547 14.966797 z M 10.443359 16.960938 C 10.698605 16.952261 10.825548 17.028659 10.898438 17.101562 C 10.995627 17.198743 11.099334 17.391254 10.998047 17.857422 C 10.89676 18.323589 10.548292 19.014181 9.78125 19.78125 C 9.0142082 20.548319 8.3235856 20.896744 7.8574219 20.998047 C 7.3912574 21.09935 7.1987491 20.995621 7.1015625 20.898438 C 7.0043761 20.801254 6.9006663 20.608746 7.0019531 20.142578 C 7.1032405 19.676411 7.4517083 18.985819 8.21875 18.21875 C 8.9857919 17.451681 9.6764148 17.103256 10.142578 17.001953 C 10.259119 16.976627 10.358277 16.96383 10.443359 16.960938 z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.blocks {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M10 3H4a1 1 0 0 0-1 1v6a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4a1 1 0 0 0-1-1zM9 9H5V5h4v4zm11 4h-6a1 1 0 0 0-1 1v6a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1v-6a1 1 0 0 0-1-1zm-1 6h-4v-4h4v4zM17 3c-2.206 0-4 1.794-4 4s1.794 4 4 4s4-1.794 4-4s-1.794-4-4-4zm0 6c-1.103 0-2-.897-2-2s.897-2 2-2s2 .897 2 2s-.897 2-2 2zM7 13c-2.206 0-4 1.794-4 4s1.794 4 4 4s4-1.794 4-4s-1.794-4-4-4zm0 6c-1.103 0-2-.897-2-2s.897-2 2-2s2 .897 2 2s-.897 2-2 2z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.bold-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M8 11h4.5a2.5 2.5 0 1 0 0-5H8v5zm10 4.5a4.5 4.5 0 0 1-4.5 4.5H6V4h6.5a4.5 4.5 0 0 1 3.256 7.606A4.498 4.498 0 0 1 18 15.5zM8 13v5h5.5a2.5 2.5 0 1 0 0-5H8z" stroke-width=".5" stroke="currentColor"></path></svg>');
+}
+body:not(.no-svg-replace) svg.italic-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 1024 1024"><path fill="red" d="M798 160H366c-4.4 0-8 3.6-8 8v64c0 4.4 3.6 8 8 8h181.2l-156 544H229c-4.4 0-8 3.6-8 8v64c0 4.4 3.6 8 8 8h432c4.4 0 8-3.6 8-8v-64c0-4.4-3.6-8-8-8H474.4l156-544H798c4.4 0 8-3.6 8-8v-64c0-4.4-3.6-8-8-8z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.bracket-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M10 4V2H4v20h6v-2H6V4zm4 16v2h6V2h-6v2h4v16z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.broken-link {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M70.833 70.833h20.833v8.333h-12.5v12.5h-8.333v-20.833zM29.167 29.167H8.333V20.833h12.5V8.333h8.333v20.833zm47.35 35.567L70.625 58.833l5.892 -5.892a20.833 20.833 0 1 0 -29.463 -29.463L41.163 29.375L35.267 23.483L41.167 17.592a29.167 29.167 0 0 1 41.25 41.25l-5.896 5.892zm-11.783 11.783l-5.896 5.892a29.167 29.167 0 0 1 -41.25 -41.25l5.896 -5.892L29.375 41.167l-5.892 5.892a20.833 20.833 0 1 0 29.463 29.463l5.892 -5.892l5.896 5.892zm-2.95 -44.196l5.896 5.896l-29.463 29.458l-5.896 -5.892l29.463 -29.458z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.bullet-list-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M16.667 25h8.333v8.333H16.667zm0 20.833h8.333v8.333H16.667zm0 20.833h8.333v8.333H16.667zm66.667 -33.333V25H33.429v8.333H78.333zM33.333 45.833h50v8.333H33.333zm0 20.833h50v8.333H33.333z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.bullet-list {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M16.667 25h8.333v8.333H16.667zm0 20.833h8.333v8.333H16.667zm0 20.833h8.333v8.333H16.667zm66.667 -33.333V25H33.429v8.333H78.333zM33.333 45.833h50v8.333H33.333zm0 20.833h50v8.333H33.333z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.calendar-with-checkmark {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M79.167 16.667h-8.333V8.333h-8.333v8.333H37.5V8.333H29.167v8.333H20.833c-4.596 0 -8.333 3.738 -8.333 8.333v58.333c0 4.596 3.738 8.333 8.333 8.333h58.333c4.596 0 8.333 -3.738 8.333 -8.333V25c0 -4.596 -3.738 -8.333 -8.333 -8.333zm0.008 66.667H20.833V33.333h58.333l0.008 50z M45.833 72.558l23.779 -23.779l-5.892 -5.892L45.833 60.775l-9.554 -9.554l-5.892 5.892z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.check-in-circle {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M50 8.333C27.025 8.333 8.333 27.025 8.333 50s18.692 41.667 41.667 41.667s41.667 -18.692 41.667 -41.667S72.975 8.333 50 8.333zm-8.329 60.054l-15.471 -15.438L32.083 47.05l9.579 9.563l22.058 -22.058l5.892 5.892l-27.942 27.942z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.check-small {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M50 8.333C27.025 8.333 8.333 27.025 8.333 50s18.692 41.667 41.667 41.667s41.667 -18.692 41.667 -41.667S72.975 8.333 50 8.333zM50 83.333c-18.379 0 -33.333 -14.954 -33.333 -33.333s14.954 -33.333 33.333 -33.333s33.333 14.954 33.333 33.333S68.379 83.333 50 83.333z M41.663 56.613L32.083 47.05 26.2 52.95 41.671 68.388 69.613 40.446 63.721 34.554z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.checkbox-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M10.933 13.519l-2.226-2.226l-1.414 1.414l3.774 3.774l5.702-6.84l-1.538-1.282z"/><path d="M19 3H5c-1.103 0-2 .897-2 2v14c0 1.103.897 2 2 2h14c1.103 0 2-.897 2-2V5c0-1.103-.897-2-2-2zM5 19V5h14l.002 14H5z" fill="currentColor"></path></svg>');
+}
+body:not(.no-svg-replace) svg.checkmark {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M41.667 64.942l-13.721 -13.721l-5.892 5.892L41.667 76.725l40.446 -40.446l-5.892 -5.892z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.clock {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M50 8.333C27.025 8.333 8.333 27.025 8.333 50s18.692 41.667 41.667 41.667s41.667 -18.692 41.667 -41.667S72.975 8.333 50 8.333zm0 75c-18.379 0 -33.333 -14.954 -33.333 -33.333s14.954 -33.333 33.333 -33.333s33.333 14.954 33.333 33.333s-14.954 33.333 -33.333 33.333z"/><path fill="red" d="M54.167 29.167h-8.333v25h25v-8.333h-16.667z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.clock-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M83.938 34.458l6.513 -6.513l-5.892 -5.892L77.442 29.167c-4.375 -2.625 -9.475 -4.167 -14.942 -4.167c-16.079 0 -29.167 13.083 -29.167 29.167s13.088 29.167 29.167 29.167s29.167 -13.083 29.167 -29.167a29.025 29.025 0 0 0 -7.729 -19.708zM62.5 75c-11.488 0 -20.833 -9.346 -20.833 -20.833s9.346 -20.833 20.833 -20.833s20.833 9.346 20.833 20.833s-9.346 20.833 -20.833 20.833z"/><path fill="red" d="M58.333 41.667h8.333v16.667h-8.333zm-4.167 -29.167h16.667v8.333h-16.667zM12.5 33.333h16.667v8.333H12.5zm0 33.333h16.667v8.333H12.5zm-4.167 -16.667h16.625v8.333H8.333z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.cloud {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M78.933 46.3C77.113 31.958 64.833 20.833 50 20.833C38.517 20.833 28.542 27.546 23.988 38.125C15.038 40.8 8.333 49.25 8.333 58.333c0 11.488 9.346 20.833 20.833 20.833h45.833c9.192 0 16.667 -7.475 16.667 -16.667a16.708 16.708 0 0 0 -12.733 -16.2zM75 70.833H29.167c-6.892 0 -12.5 -5.608 -12.5 -12.5c0 -5.85 4.996 -11.483 11.138 -12.563l2.421 -0.425l0.8 -2.325C33.954 34.475 41.229 29.167 50 29.167c11.488 0 20.833 9.346 20.833 20.833v4.167h4.167c4.596 0 8.333 3.738 8.333 8.333s-3.738 8.333 -8.333 8.333z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.code-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M14.6 16.6l4.6-4.6l-4.6-4.6L16 6l6 6l-6 6l-1.4-1.4m-5.2 0L4.8 12l4.6-4.6L8 6l-6 6l6 6l1.4-1.4z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.create-new {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M54.167 29.167h-8.333v16.667H29.167v8.333h16.667v16.667h8.333v-16.667h16.667v-8.333h-16.667z"/><path fill="red" d="M50 8.333C27.025 8.333 8.333 27.025 8.333 50s18.692 41.667 41.667 41.667s41.667 -18.692 41.667 -41.667S72.975 8.333 50 8.333zm0 75c-18.379 0 -33.333 -14.954 -33.333 -33.333s14.954 -33.333 33.333 -33.333s33.333 14.954 33.333 33.333s-14.954 33.333 -33.333 33.333z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.cross-in-box {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M79.167 12.5H20.833a8.333 8.333 0 0 0 -8.333 8.333v58.333a8.333 8.333 0 0 0 8.333 8.333h58.333a8.333 8.333 0 0 0 8.333 -8.333V20.833a8.333 8.333 0 0 0 -8.333 -8.333m0 66.667H20.833V20.833h58.333v58.333M70.833 35L55.833 50l15 15l-5.833 5.833l-15 -15L35 70.833L29.167 65l15 -15L29.167 35L35 29.167l15 15L65 29.167L70.833 35z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.cross {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M67.467 26.433l-17.679 17.675l-17.675 -17.675l-5.892 5.892L43.896 50l-17.675 17.675l5.892 5.892l17.675 -17.675l17.679 17.675l5.892 -5.892L55.683 50l17.675 -17.675z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.crossed-star {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M20.938 86.563A4.158 4.158 0 0 0 25 91.667a4.167 4.167 0 0 0 2.313 -0.7L50 75.842l22.688 15.125a4.171 4.171 0 0 0 6.321 -4.608l-7.621 -26.667l18.9 -17.008a4.167 4.167 0 0 0 -2.458 -7.25l-23.754 -1.892l-10.279 -22.754a4.158 4.158 0 0 0 -7.592 -0.004L35.925 33.542l-23.754 1.888a4.167 4.167 0 0 0 -2.579 7.138l17.558 17.113l-6.213 26.883zM50 22.621l8.508 18.838l2.45 0.196h0.004l16.55 1.313l-13.629 12.267l-0.004 0.008l-1.929 1.733l0.713 2.488v0.013l5.221 18.271L50 65.825V22.621z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.dice {
+  /*comeback*/
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M79.167 12.5H20.833c-4.596 0 -8.333 3.738 -8.333 8.333v58.333c0 4.596 3.738 8.333 8.333 8.333h58.333c4.596 0 8.333 -3.738 8.333 -8.333V20.833c0 -4.596 -3.738 -8.333 -8.333 -8.333zM20.833 79.167V20.833h58.333l0.008 58.333H20.833z M39.583 33.333A6.25 6.25 0 0 1 33.333 39.583A6.25 6.25 0 0 1 27.083 33.333A6.25 6.25 0 0 1 39.583 33.333z M56.25 50A6.25 6.25 0 0 1 50 56.25A6.25 6.25 0 0 1 43.75 50A6.25 6.25 0 0 1 56.25 50z M72.917 66.667A6.25 6.25 0 0 1 66.667 72.917A6.25 6.25 0 0 1 60.417 66.667A6.25 6.25 0 0 1 72.917 66.667z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.document {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M83.071 36.167c-0.046 -0.133 -0.083 -0.263 -0.138 -0.392c-0.204 -0.442 -0.458 -0.863 -0.817 -1.221l-25 -25c-0.358 -0.358 -0.779 -0.613 -1.221 -0.817c-0.125 -0.058 -0.258 -0.092 -0.392 -0.138c-0.35 -0.117 -0.708 -0.192 -1.079 -0.212C54.333 8.379 54.254 8.333 54.167 8.333H25C20.404 8.333 16.667 12.071 16.667 16.667v66.667c0 4.596 3.738 8.333 8.333 8.333h50c4.596 0 8.333 -3.738 8.333 -8.333V37.5c0 -0.088 -0.046 -0.167 -0.054 -0.258C83.258 36.875 83.188 36.517 83.071 36.167zM69.108 33.333H58.333V22.558L69.108 33.333zM25 83.333V16.667h25v20.833c0 2.304 1.863 4.167 4.167 4.167h20.833l0.008 41.667H25z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.documents {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M83.333 8.333H41.667C37.071 8.333 33.333 12.071 33.333 16.667v16.667H16.667c-4.596 0 -8.333 3.738 -8.333 8.333v41.667c0 4.596 3.738 8.333 8.333 8.333h41.667c4.596 0 8.333 -3.738 8.333 -8.333v-16.667h16.667c4.596 0 8.333 -3.738 8.333 -8.333V16.667C91.667 12.071 87.929 8.333 83.333 8.333zM16.667 83.333V41.667h41.667l0.008 41.667H16.667zM83.333 58.333h-16.667v-16.667c0 -4.596 -3.738 -8.333 -8.333 -8.333h-16.667V16.667h41.667V58.333z M25 50H50V58.333H25zM25 66.667H50V75H25z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.dot-network {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M81.25 12.5C75.504 12.5 70.833 17.171 70.833 22.917c0 1.488 0.325 2.9 0.892 4.188l-8.146 9.162C60.896 34.425 57.663 33.333 54.167 33.333c-3.083 0 -5.933 0.9 -8.413 2.358L36.279 26.221L36.183 26.317C37 24.658 37.5 22.813 37.5 20.833c0 -6.904 -5.596 -12.5 -12.5 -12.5S12.5 13.929 12.5 20.833s5.596 12.5 12.5 12.5c1.979 0 3.821 -0.5 5.483 -1.317L30.388 32.113L39.863 41.583C38.396 44.067 37.5 46.921 37.5 50c0 4.154 1.583 7.913 4.104 10.838l-10.738 10.733C29.692 71.108 28.421 70.833 27.083 70.833C21.342 70.833 16.667 75.504 16.667 81.25S21.342 91.667 27.083 91.667S37.5 86.996 37.5 81.25c0 -1.338 -0.275 -2.608 -0.738 -3.788l11.825 -11.825C50.342 66.263 52.2 66.667 54.167 66.667c9.192 0 16.667 -7.475 16.667 -16.667c0 -2.65 -0.679 -5.121 -1.783 -7.35l8.821 -9.929C78.938 33.087 80.063 33.333 81.25 33.333C86.996 33.333 91.667 28.663 91.667 22.917S86.996 12.5 81.25 12.5zM54.167 58.333c-4.596 0 -8.333 -3.738 -8.333 -8.333s3.738 -8.333 8.333 -8.333c4.596 0 8.333 3.738 8.333 8.333S58.763 58.333 54.167 58.333z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.double-down-arrow-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M16.59 5.59L18 7l-6 6l-6-6l1.41-1.41L12 10.17l4.59-4.58m0 6L18 13l-6 6l-6-6l1.41-1.41L12 16.17l4.59-4.58z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.double-up-arrow-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M7.41 18.41L6 17l6-6l6 6l-1.41 1.41L12 13.83l-4.59 4.58m0-6L6 11l6-6l6 6l-1.41 1.41L12 7.83l-4.59 4.58z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.down-arrow-with-tail {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M77.946 52.946l-5.892 -5.892L54.167 64.942V25h-8.333v39.942l-17.888 -17.888l-5.892 5.892L50 80.892z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.down-chevron-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M67.888 38.721L50 56.608L32.113 38.721l-5.892 5.892L50 68.392l23.779 -23.779z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.enter {
+  transform: translate(-2px);
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M54.167 66.667l20.833 -16.667l-20.833 -16.667v12.5H16.667v8.333h37.5z"/><path fill="red" d="M83.333 12.5h-37.5c-4.596 0 -8.333 3.738 -8.333 8.333v16.667h8.333V20.833h37.5v58.333h-37.5v-16.667H37.5v16.667c0 4.596 3.738 8.333 8.333 8.333h37.5c4.596 0 8.333 -3.738 8.333 -8.333V20.833c0 -4.596 -3.738 -8.333 -8.333 -8.333z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.exit-fullscreen {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M41.667 16.667H33.333v16.667H16.667v8.333h25zM33.333 83.333h8.333v-25H16.667v8.333h16.667zm50 -25h-25v25h8.333v-16.667h16.667zm0 -25h-16.667V16.667h-8.333v25h25z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.expand-vertically {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M29.167 70.833L50 91.667 70.833 70.833 54.167 70.833 54.167 29.167 70.833 29.167 50 8.333 29.167 29.167 45.833 29.167 45.833 70.833z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.filled-pin {
+  transform: rotate(45deg);
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M12 22l1-2v-3h5a1 1 0 0 0 1-1v-1.586c0-.526-.214-1.042-.586-1.414L17 11.586V8a1 1 0 0 0 1-1V4c0-1.103-.897-2-2-2H8c-1.103 0-2 .897-2 2v3a1 1 0 0 0 1 1v3.586L5.586 13A2.01 2.01 0 0 0 5 14.414V16a1 1 0 0 0 1 1h5v3l1 2zM8 4h8v2H8V4zM7 14.414l1.707-1.707A.996.996 0 0 0 9 12V8h6v4c0 .266.105.52.293.707L17 14.414V15H7v-.586z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.folder {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M83.333 75H16.667V33.333h66.667m0 -8.333h-33.333l-8.333 -8.333H16.667c-4.625 0 -8.333 3.708 -8.333 8.333v50a8.333 8.333 0 0 0 8.333 8.333h66.667a8.333 8.333 0 0 0 8.333 -8.333V33.333a8.333 8.333 0 0 0 -8.333 -8.333z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.fullscreen {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M20.833 20.833h20.833V12.5H12.5v29.167h8.333zm20.833 58.333H20.833v-20.833H12.5v29.167h29.167zm45.833 -20.833h-8.333v20.833h-20.833v8.333h29.167zm-8.333 -16.667h8.333V12.5h-29.167v8.333h20.833z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.gear {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M50 66.667c9.192 0 16.667 -7.475 16.667 -16.667s-7.475 -16.667 -16.667 -16.667s-16.667 7.475 -16.667 16.667s7.475 16.667 16.667 16.667zm0 -25c4.517 0 8.333 3.817 8.333 8.333s-3.817 8.333 -8.333 8.333s-8.333 -3.817 -8.333 -8.333s3.817 -8.333 8.333 -8.333z"/><path fill="red" d="M11.854 67.233l4.167 7.208c2.213 3.821 7.538 5.254 11.375 3.042l2.204 -1.275A33.75 33.75 0 0 0 37.5 80.842V83.333c0 4.596 3.738 8.333 8.333 8.333h8.333c4.596 0 8.333 -3.738 8.333 -8.333v-2.492a33.883 33.883 0 0 0 7.9 -4.629l2.204 1.275c3.846 2.208 9.158 0.783 11.379 -3.046l4.163 -7.204a8.338 8.338 0 0 0 -3.046 -11.383l-2.104 -1.217a32.158 32.158 0 0 0 0 -9.267l2.104 -1.217a8.342 8.342 0 0 0 3.046 -11.383l-4.163 -7.204c-2.213 -3.833 -7.533 -5.271 -11.379 -3.05l-2.204 1.275A33.75 33.75 0 0 0 62.5 19.158V16.667c0 -4.596 -3.738 -8.333 -8.333 -8.333h-8.333c-4.596 0 -8.333 3.738 -8.333 8.333v2.492a33.883 33.883 0 0 0 -7.9 4.629l-2.204 -1.275c-3.85 -2.213 -9.167 -0.779 -11.379 3.05l-4.163 7.204a8.338 8.338 0 0 0 3.046 11.383l2.104 1.217a32.013 32.013 0 0 0 0 9.262l-2.104 1.217a8.346 8.346 0 0 0 -3.046 11.388zm13.858 -11.492A23.763 23.763 0 0 1 25 50c0 -1.925 0.242 -3.858 0.708 -5.742a4.163 4.163 0 0 0 -1.958 -4.617l-4.679 -2.708l4.158 -7.204l4.771 2.758a4.154 4.154 0 0 0 4.95 -0.592a25.296 25.296 0 0 1 9.933 -5.829A4.167 4.167 0 0 0 45.833 22.083V16.667h8.333v5.417a4.167 4.167 0 0 0 2.95 3.983a25.346 25.346 0 0 1 9.933 5.829a4.163 4.163 0 0 0 4.95 0.592l4.767 -2.754l4.167 7.204l-4.683 2.704a4.167 4.167 0 0 0 -1.958 4.617c0.467 1.883 0.708 3.817 0.708 5.742c0 1.921 -0.242 3.854 -0.713 5.742a4.167 4.167 0 0 0 1.963 4.617l4.679 2.704l-4.158 7.204l-4.771 -2.754a4.15 4.15 0 0 0 -4.95 0.592a25.296 25.296 0 0 1 -9.933 5.829A4.167 4.167 0 0 0 54.167 77.917l0.008 5.417H45.833v-5.417a4.167 4.167 0 0 0 -2.95 -3.983a25.346 25.346 0 0 1 -9.933 -5.829a4.133 4.133 0 0 0 -4.95 -0.588l-4.767 2.758l-4.167 -7.204l4.683 -2.713a4.167 4.167 0 0 0 1.963 -4.617z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.hashtag {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M66.742 15.896L63.467 33.333h-20.692l2.983 -15.896l-8.183 -1.542L34.3 33.333H16.667v8.333h16.071l-3.129 16.667H12.5v8.333h15.546l-2.975 15.854l8.188 1.538L36.525 66.667h20.692l-2.975 15.854l8.188 1.538l3.263 -17.392H83.333v-8.333h-16.079l3.129 -16.667H87.5V33.333h-15.554l2.983 -15.896l-8.188 -1.542zM58.775 58.333H38.088l3.129 -16.667h20.692l-3.133 16.667z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.heading-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M18 20V4h-3v6H9V4H6v16h3v-7h6v7z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.go-to-file {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M57.113 9.554C56.333 8.771 55.275 8.333 54.167 8.333H25C20.404 8.333 16.667 12.071 16.667 16.667v66.667c0 4.596 3.738 8.333 8.333 8.333h50c4.596 0 8.333 -3.738 8.333 -8.333V37.5c0 -1.108 -0.438 -2.167 -1.221 -2.946L57.113 9.554zM25 16.667h27.442L75 39.225l0.008 38.225l-10.7 -10.7C65.767 64.271 66.667 61.413 66.667 58.333c0 -9.192 -7.475 -16.667 -16.667 -16.667s-16.667 7.475 -16.667 16.667s7.475 16.667 16.667 16.667c3.079 0 5.938 -0.9 8.417 -2.358L69.108 83.333H25V16.667zM50 66.667c-4.596 0 -8.333 -3.738 -8.333 -8.333s3.738 -8.333 8.333 -8.333s8.333 3.738 8.333 8.333S54.596 66.667 50 66.667z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.help .widget-icon,
+body:not(.no-svg-replace) svg.help {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M50 25C40.962 25 33.608 32.354 33.608 41.392h8.333C41.942 36.946 45.558 33.333 50 33.333s8.058 3.613 8.058 8.058c0 2.492 -2.004 4.3 -5.067 6.775 -1.063 0.863 -2.067 1.683 -2.879 2.496C45.954 54.817 45.833 59.229 45.833 59.721V62.5h8.333l-0.004 -2.638c0.004 -0.067 0.138 -1.608 1.838 -3.304 0.625 -0.625 1.413 -1.25 2.229 -1.908 3.246 -2.629 8.158 -6.6 8.158 -13.258C66.392 32.354 59.038 25 50 25zM45.833 66.667H54.167V75H45.833z M50 8.333C27.025 8.333 8.333 27.025 8.333 50s18.692 41.667 41.667 41.667s41.667 -18.692 41.667 -41.667S72.975 8.333 50 8.333zM50 83.333c-18.379 0 -33.333 -14.954 -33.333 -33.333s14.954 -33.333 33.333 -33.333s33.333 14.954 33.333 33.333S68.379 83.333 50 83.333z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.highlight-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M86.279 24.275l-14.729 -14.721c-1.617 -1.621 -4.237 -1.629 -5.867 -0.025L29.567 45.083c-0.563 0.558 -0.958 1.262 -1.138 2.033l-4.267 18.488L16.667 75h11.783l4.758 -4.704 14.95 -3.45c0.75 -0.175 1.438 -0.554 1.988 -1.092l36.113 -35.563C87.05 29.413 87.496 28.35 87.5 27.238S87.067 25.063 86.279 24.275zM47.242 56.913l-8.838 -8.833 30.179 -29.713 8.833 8.833L47.242 56.913zM16.667 83.333H83.333V91.667H16.667z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.horizontal-split {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M33.333 75h12.5v-12.5H8.333v-8.333h83.333v8.333h-37.5v12.5h12.5l-16.667 16.667l-16.667 -16.667m16.667 -66.667L33.333 25h12.5v12.5H8.333v8.333h83.333V37.5h-37.5V25h12.5l-16.667 -16.667z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.image-file {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M37.496 39.583A6.25 6.25 0 0 1 31.246 45.833A6.25 6.25 0 0 1 24.996 39.583A6.25 6.25 0 0 1 37.496 39.583z"/><path fill="red" d="M43.746 58.333l-6.25 -8.333l-12.5 16.667h50l-18.75 -25z"/><path fill="red" d="M83.329 16.667h-66.667c-4.596 0 -8.333 3.738 -8.333 8.333v50c0 4.596 3.738 8.333 8.333 8.333h66.667c4.596 0 8.333 -3.738 8.333 -8.333V25c0 -4.596 -3.738 -8.333 -8.333 -8.333zm-66.667 58.333V25h66.667l0.008 50H16.663z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.image-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M37.496 39.583A6.25 6.25 0 0 1 31.246 45.833A6.25 6.25 0 0 1 24.996 39.583A6.25 6.25 0 0 1 37.496 39.583z"/><path fill="red" d="M43.746 58.333l-6.25 -8.333l-12.5 16.667h50l-18.75 -25z"/><path fill="red" d="M83.329 16.667h-66.667c-4.596 0 -8.333 3.738 -8.333 8.333v50c0 4.596 3.738 8.333 8.333 8.333h66.667c4.596 0 8.333 -3.738 8.333 -8.333V25c0 -4.596 -3.738 -8.333 -8.333 -8.333zm-66.667 58.333V25h66.667l0.008 50H16.663z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.indent-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M45.833 54.167h41.667v-8.333H45.833m0 -8.333h41.667V29.167H45.833M12.5 12.5v8.333h75V12.5M45.833 70.833h41.667v-8.333H45.833M12.5 33.333v33.333l16.667 -16.667m-16.667 37.5h75v-8.333H12.5v8.333z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.info {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M50 8.333C27.025 8.333 8.333 27.025 8.333 50s18.692 41.667 41.667 41.667s41.667 -18.692 41.667 -41.667S72.975 8.333 50 8.333zm0 75c-18.379 0 -33.333 -14.954 -33.333 -33.333s14.954 -33.333 33.333 -33.333s33.333 14.954 33.333 33.333s-14.954 33.333 -33.333 33.333z"/><path fill="red" d="M45.833 45.833h8.333v25h-8.333zm0 -16.667h8.333v8.333h-8.333z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.install {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M50 66.667l16.667 -20.833h-12.5V16.667h-8.333v29.167H33.333z"/><path fill="red" d="M83.333 75H16.667v-29.167H8.333v29.167c0 4.596 3.738 8.333 8.333 8.333h66.667c4.596 0 8.333 -3.738 8.333 -8.333v-29.167h-8.333v29.167z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.keyboard-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M4 5a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2H4m0 2h16v10H4V7m1 1v2h2V8H5m3 0v2h2V8H8m3 0v2h2V8h-2m3 0v2h2V8h-2m3 0v2h2V8h-2M5 11v2h2v-2H5m3 0v2h2v-2H8m3 0v2h2v-2h-2m3 0v2h2v-2h-2m3 0v2h2v-2h-2m-9 3v2h8v-2H8z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.left-arrow-with-tail {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M52.946 72.054L35.058 54.167H75v-8.333H35.058l17.888 -17.888l-5.892 -5.892L19.108 50l27.946 27.946z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.left-arrow {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M58.079 20.579L28.663 50 58.079 79.421 66.921 70.579 46.338 50 66.921 29.421z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.left-chevron-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M58.079 20.579L28.663 50l29.417 29.421l8.842 -8.842L46.338 50l20.583 -20.579z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.lines-of-text {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M83.333 12.5H16.667c-4.596 0 -8.333 3.738 -8.333 8.333v58.333c0 4.596 3.738 8.333 8.333 8.333h66.667c4.596 0 8.333 -3.738 8.333 -8.333V20.833c0 -4.596 -3.738 -8.333 -8.333 -8.333zM16.667 79.167V20.833h66.667l0.008 58.333H16.667z M25 29.167h50v8.333H25zm0 16.667h50v8.333H25zm0 16.667h25v8.333H25z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.link-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M54.417 33.792l5.896 5.896a29.167 29.167 0 0 1 0 41.25l-1.475 1.471a29.167 29.167 0 0 1 -41.25 -41.25l5.896 5.896a20.833 20.833 0 1 0 29.463 29.463l1.475 -1.475a20.833 20.833 0 0 0 0 -29.458l-5.896 -5.896l5.896 -5.892zm27.992 25.046l-5.892 -5.892a20.833 20.833 0 1 0 -29.463 -29.463l-1.475 1.475a20.833 20.833 0 0 0 0 29.458l5.896 5.896l-5.896 5.892l-5.892 -5.892a29.167 29.167 0 0 1 0 -41.25l1.475 -1.471a29.167 29.167 0 0 1 41.25 41.25z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.link {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M18.364 15.536L16.95 14.12l1.414-1.414a5 5 0 1 0-7.071-7.071L9.879 7.05L8.464 5.636L9.88 4.222a7 7 0 0 1 9.9 9.9l-1.415 1.414zm-2.828 2.828l-1.415 1.414a7 7 0 0 1-9.9-9.9l1.415-1.414L7.05 9.88l-1.414 1.414a5 5 0 1 0 7.071 7.071l1.414-1.414l1.415 1.414zm-.708-10.607l1.415 1.415l-7.071 7.07l-1.415-1.414l7.071-7.07z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.magnifying-glass {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M10 18a7.952 7.952 0 0 0 4.897-1.688l4.396 4.396l1.414-1.414l-4.396-4.396A7.952 7.952 0 0 0 18 10c0-4.411-3.589-8-8-8s-8 3.589-8 8s3.589 8 8 8zm0-14c3.309 0 6 2.691 6 6s-2.691 6-6 6s-6-2.691-6-6s2.691-6 6-6z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.microphone-filled {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M50 66.667c9.192 0 16.667 -7.475 16.667 -16.667V25c0 -9.238 -7.438 -16.754 -16.579 -16.754c-0.288 0 -0.583 0.037 -0.871 0.104C40.388 8.767 33.333 16.071 33.333 25v25C33.333 59.192 40.808 66.667 50 66.667z M45.833 83.046V91.667h8.333v-8.621c16.413 -2.063 29.167 -16.075 29.167 -33.046h-8.333c0 13.788 -11.213 25 -25 25s-25 -11.213 -25 -25H16.667C16.667 66.967 29.421 80.983 45.833 83.046z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.microphone {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="black" d="M66.667 50V25c0 -9.238 -7.438 -16.754 -16.579 -16.754a3.888 3.888 0 0 0 -0.871 0.104A16.692 16.692 0 0 0 33.333 25v25c0 9.192 7.475 16.667 16.667 16.667s16.667 -7.475 16.667 -16.667zm-25 0V25c0 -4.596 3.738 -8.333 8.333 -8.333a3.708 3.708 0 0 0 0.679 -0.063C54.95 16.917 58.333 20.563 58.333 25v25c0 4.596 -3.738 8.333 -8.333 8.333s-8.333 -3.738 -8.333 -8.333z M25 50H16.667c0 16.967 12.754 30.983 29.167 33.046V91.667h8.333v-8.621c16.413 -2.063 29.167 -16.075 29.167 -33.046h-8.333c0 13.788 -11.213 25 -25 25s-25 -11.213 -25 -25z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.minus-with-circle {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M29.167 45.833h41.667v8.333H29.167z"/><path fill="red" d="M50 8.333C27.025 8.333 8.333 27.025 8.333 50s18.692 41.667 41.667 41.667s41.667 -18.692 41.667 -41.667S72.975 8.333 50 8.333zm0 75c-18.379 0 -33.333 -14.954 -33.333 -33.333s14.954 -33.333 33.333 -33.333s33.333 14.954 33.333 33.333s-14.954 33.333 -33.333 33.333z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.note-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="black" d="M19 3H5c-1.103 0-2 .897-2 2v14c0 1.103.897 2 2 2h8a.996.996 0 0 0 .707-.293l7-7a.997.997 0 0 0 .196-.293c.014-.03.022-.061.033-.093a.991.991 0 0 0 .051-.259c.002-.021.013-.041.013-.062V5c0-1.103-.897-2-2-2zM5 5h14v7h-6a1 1 0 0 0-1 1v6H5V5zm9 12.586V14h3.586L14 17.586z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.number-list-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M2 17h2v.5H3v1h1v.5H2v1h3v-4H2v1zm1-9h1V4H2v1h1v3zm-1 3h1.8L2 13.1v.9h3v-1H3.2L5 10.9V10H2v1zm5-6v2h14V5H7zm0 14h14v-2H7v2zm0-6h14v-2H7v2z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.open-vault {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="black" d="M83.333 84.721V91.667h-8.333v-5.554l-30.908 5.15A2.083 2.083 0 0 1 41.667 89.208V83.333H25v8.333H16.667v-8.333H12.5a4.167 4.167 0 0 1 -4.167 -4.167V16.667a4.167 4.167 0 0 1 4.167 -4.167h29.167V6.625a2.083 2.083 0 0 1 2.425 -2.054l44.092 7.35a4.167 4.167 0 0 1 3.483 4.108V25h4.167v8.333h-4.167v29.167h4.167v8.333h-4.167v8.971a4.167 4.167 0 0 1 -3.483 4.108L83.333 84.721zM16.667 20.833v54.167h25V20.833H16.667zm33.333 61l33.333 -5.558V19.558l-33.333 -5.554v67.825zM68.75 58.333c-3.45 0 -6.25 -4.667 -6.25 -10.417S65.3 37.5 68.75 37.5s6.25 4.667 6.25 10.417s-2.8 10.417 -6.25 10.417z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.pane-layout {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M4 4h16a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2zm0 2v5h4V6H4zm0 7v5h4v-5H4zm6-7v12h10V6H10z" ></path></svg>');
+}
+body:not(.no-svg-replace) svg.paper-plane {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="black" d="M85.679 13.917a4.175 4.175 0 0 0 -4.121 -0.329l-70.833 33.333a4.167 4.167 0 0 0 0.108 7.588L33.333 64.354v28.008l24.317 -17.367l19.85 8.683a4.167 4.167 0 0 0 5.829 -3.542l4.167 -62.5a4.188 4.188 0 0 0 -1.817 -3.721zm-10.275 59.75l-21.954 -9.608L66.667 38.196l-31.871 17.708l-12.217 -5.346l56.129 -26.417l-3.304 49.525z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.paused {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="black" d="M50 8.333C27.025 8.333 8.333 27.025 8.333 50s18.692 41.667 41.667 41.667s41.667 -18.692 41.667 -41.667S72.975 8.333 50 8.333zm0 75c-18.379 0 -33.333 -14.954 -33.333 -33.333s14.954 -33.333 33.333 -33.333s33.333 14.954 33.333 33.333s-14.954 33.333 -33.333 33.333z"/><path fill="red" d="M54.167 37.5h8.333v25h-8.333zM37.5 37.5h8.333v25H37.5z"></path></svg>');
+}
+/*
+body:not(.no-svg-replace) svg.pdf-file{
+-webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2m0 2v14H5V5h14m-1.1 8.5c-.3-.5-1-.7-2.2-.7c-.4 0-.8 0-1.2.1c-.3-.2-.6-.4-.8-.6c-.6-.5-1.2-1.4-1.5-2.5v-.1c.3-1.3.6-2.8 0-3.5c-.3-.1-.5-.2-.7-.2h-.2c-.4 0-.7.4-.8.7c-.4 1.3-.1 2 .2 3.2c-.2.9-.6 1.8-1 2.8c-.4.7-.7 1.3-1 1.8c-.4.2-.7.3-.9.5c-1.1.7-1.7 1.5-1.8 2v.5l.5.3c.2.2.3.2.5.2c.8 0 1.7-.9 2.9-3h.1c1-.3 2.2-.5 3.9-.7c1 .5 2.2.7 2.9.7c.4 0 .7-.1.9-.3c.2-.2.3-.4.3-.6c0-.3 0-.5-.1-.6M6.8 17.3c0-.4.5-1 1.2-1.6c.1-.1.3-.2.5-.3c-.7 1.1-1.3 1.8-1.7 1.9m4.5-10.6s0-.1.1-.1h.1c.2.2.2.5.1 1.1v.2c-.1.2-.1.5-.2.8c-.3-.9-.3-1.6-.1-2m-1.2 7.6H10c.1-.3.3-.6.5-1c.4-.8.8-1.6 1-2.3c.4.9.9 1.6 1.5 2.1c.1.1.3.2.4.3c-.9.1-2.1.4-3.3.9m7.2-.1h-.2c-.4 0-1.1-.2-1.8-.5c.1-.1.2-.1.2-.1c1.4 0 1.7.2 1.8.3l.1.1c0 .2 0 .2-.1.2z"></path></svg>');
+}*/
+body:not(.no-svg-replace) svg.pencil {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M16.679 87.5c0.338 0 0.675 -0.042 1.008 -0.125l16.667 -4.167c0.733 -0.183 1.404 -0.563 1.938 -1.096L87.513 30.892c1.575 -1.575 2.442 -3.667 2.442 -5.892s-0.867 -4.317 -2.442 -5.892L80.904 12.5c-3.15 -3.15 -8.633 -3.15 -11.783 0L17.9 63.721a4.179 4.179 0 0 0 -1.096 1.933l-4.167 16.667A4.167 4.167 0 0 0 16.679 87.5zm58.333 -69.108L81.621 25l-6.608 6.608L68.404 25l6.608 -6.608zM24.608 68.796l37.904 -37.904L69.121 37.5l-37.908 37.904l-8.808 2.2l2.204 -8.808z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.pin {
+  transform: rotate(45deg);
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M12 22l1-2v-3h5a1 1 0 0 0 1-1v-1.586c0-.526-.214-1.042-.586-1.414L17 11.586V8a1 1 0 0 0 1-1V4c0-1.103-.897-2-2-2H8c-1.103 0-2 .897-2 2v3a1 1 0 0 0 1 1v3.586L5.586 13A2.01 2.01 0 0 0 5 14.414V16a1 1 0 0 0 1 1h5v3l1 2zM8 4h8v2H8V4zM7 14.414l1.707-1.707A.996.996 0 0 0 9 12V8h6v4c0 .266.105.52.293.707L17 14.414V15H7v-.586z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.plus-with-circle {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M54.167 29.167h-8.333v16.667H29.167v8.333h16.667v16.667h8.333v-16.667h16.667v-8.333h-16.667z M50 8.333C27.025 8.333 8.333 27.025 8.333 50s18.692 41.667 41.667 41.667s41.667 -18.692 41.667 -41.667S72.975 8.333 50 8.333zm0 75c-18.379 0 -33.333 -14.954 -33.333 -33.333s14.954 -33.333 33.333 -33.333s33.333 14.954 33.333 33.333s-14.954 33.333 -33.333 33.333z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.popup-open {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M83.333 12.5H16.667c-4.596 0 -8.333 3.738 -8.333 8.333v58.333c0 4.596 3.738 8.333 8.333 8.333h20.833v-8.333H16.667V29.167h66.667v50h-20.833v8.333h20.833c4.596 0 8.333 -3.738 8.333 -8.333V20.833c0 -4.596 -3.738 -8.333 -8.333 -8.333z M54.167 87.5v-20.833h12.5l-16.667 -20.833l-16.667 20.833h12.5v20.833z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.presentation {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M83.333 12.5H16.667c-4.596 0 -8.333 3.738 -8.333 8.333v41.667c0 4.596 3.738 8.333 8.333 8.333h29.167v12.5H33.333v8.333h33.333v-8.333h-12.5v-12.5h29.167c4.596 0 8.333 -3.738 8.333 -8.333V20.833c0 -4.596 -3.738 -8.333 -8.333 -8.333zM16.667 62.5V20.833h66.667l0.004 41.667H16.667z M41.667 54.167l20.833 -12.5l-20.833 -12.5z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.price-tag-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M48.779 9.554C48 8.771 46.938 8.333 45.833 8.333H25C23.896 8.333 22.833 8.771 22.054 9.554l-12.5 12.5C8.771 22.833 8.333 23.892 8.333 25v20.833c0 1.108 0.438 2.167 1.221 2.946l41.667 41.667C52.033 91.258 53.1 91.667 54.167 91.667s2.133 -0.408 2.946 -1.221l33.333 -33.333c1.629 -1.629 1.629 -4.263 0 -5.892L48.779 9.554zM54.167 81.608l-37.5 -37.5V26.725L26.725 16.667h17.383l37.5 37.5L54.167 81.608z M41.667 34.804A6.863 6.863 0 0 1 34.804 41.667A6.863 6.863 0 0 1 27.942 34.804A6.863 6.863 0 0 1 41.667 34.804z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.quote-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="black" d="M6.5 10c-.223 0-.437.034-.65.065c.069-.232.14-.468.254-.68c.114-.308.292-.575.469-.844c.148-.291.409-.488.601-.737c.201-.242.475-.403.692-.604c.213-.21.492-.315.714-.463c.232-.133.434-.28.65-.35l.539-.222l.474-.197l-.485-1.938l-.597.144c-.191.048-.424.104-.689.171c-.271.05-.56.187-.882.312c-.318.142-.686.238-1.028.466c-.344.218-.741.4-1.091.692c-.339.301-.748.562-1.05.945c-.33.358-.656.734-.909 1.162c-.293.408-.492.856-.702 1.299c-.19.443-.343.896-.468 1.336c-.237.882-.343 1.72-.384 2.437c-.034.718-.014 1.315.028 1.747c.015.204.043.402.063.539l.025.168l.026-.006A4.5 4.5 0 1 0 6.5 10zm11 0c-.223 0-.437.034-.65.065c.069-.232.14-.468.254-.68c.114-.308.292-.575.469-.844c.148-.291.409-.488.601-.737c.201-.242.475-.403.692-.604c.213-.21.492-.315.714-.463c.232-.133.434-.28.65-.35l.539-.222l.474-.197l-.485-1.938l-.597.144c-.191.048-.424.104-.689.171c-.271.05-.56.187-.882.312c-.317.143-.686.238-1.028.467c-.344.218-.741.4-1.091.692c-.339.301-.748.562-1.05.944c-.33.358-.656.734-.909 1.162c-.293.408-.492.856-.702 1.299c-.19.443-.343.896-.468 1.336c-.237.882-.343 1.72-.384 2.437c-.034.718-.014 1.315.028 1.747c.015.204.043.402.063.539l.025.168l.026-.006A4.5 4.5 0 1 0 17.5 10z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.redo-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M37.5 75h12.5v-8.333H37.5c-6.892 0 -12.5 -5.608 -12.5 -12.5s5.608 -12.5 12.5 -12.5h25v12.5l20.833 -16.667l-20.833 -16.667v12.5H37.5c-11.488 0 -20.833 9.346 -20.833 20.833S26.013 75 37.5 75z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.reset {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M50 66.667c6.963 0 12.5 -5.546 12.5 -12.5s-5.538 -12.5 -12.5 -12.5s-12.5 5.546 -12.5 12.5S43.038 66.667 50 66.667z M86.738 46.608c-0.5 -2.429 -1.238 -4.796 -2.188 -7.033c-0.938 -2.217 -2.1 -4.358 -3.458 -6.379c-1.35 -1.996 -2.888 -3.858 -4.575 -5.538c-1.683 -1.692 -3.554 -3.233 -5.55 -4.588c-2.013 -1.358 -4.158 -2.517 -6.367 -3.454c-2.242 -0.954 -4.608 -1.688 -7.046 -2.192c-2.5 -0.513 -5.079 -0.758 -7.658 -0.75V8.333L33.333 20.833l16.563 12.5V25.008C51.913 25 53.929 25.192 55.875 25.592c1.892 0.392 3.733 0.963 5.475 1.704c1.721 0.725 3.388 1.633 4.95 2.683c1.554 1.05 3.008 2.25 4.325 3.571c1.313 1.308 2.517 2.763 3.558 4.313c1.058 1.567 1.963 3.233 2.692 4.963c0.742 1.738 1.308 3.579 1.7 5.463C78.967 50.2 79.167 52.179 79.167 54.167s-0.2 3.967 -0.592 5.875c-0.392 1.892 -0.958 3.733 -1.7 5.479c-0.729 1.721 -1.633 3.388 -2.683 4.95c-1.054 1.554 -2.258 3.008 -3.575 4.329c-1.313 1.317 -2.763 2.513 -4.317 3.558c-1.55 1.046 -3.213 1.95 -4.954 2.688c-1.738 0.738 -3.575 1.308 -5.463 1.7c-3.833 0.783 -7.942 0.783 -11.758 0c-1.892 -0.392 -3.733 -0.963 -5.475 -1.704c-1.733 -0.733 -3.396 -1.638 -4.954 -2.688c-1.546 -1.042 -2.996 -2.242 -4.313 -3.558c-1.313 -1.317 -2.517 -2.771 -3.563 -4.317c-1.058 -1.567 -1.963 -3.233 -2.692 -4.958c-0.742 -1.742 -1.308 -3.583 -1.7 -5.467C21.033 58.133 20.833 56.154 20.833 54.167H12.5c0 2.546 0.258 5.088 0.763 7.558c0.5 2.425 1.238 4.792 2.188 7.038c0.938 2.217 2.1 4.358 3.462 6.379c1.346 1.988 2.883 3.85 4.571 5.538c1.692 1.696 3.558 3.238 5.546 4.579c1.996 1.354 4.142 2.517 6.371 3.458c2.242 0.954 4.608 1.688 7.046 2.192C44.913 91.408 47.454 91.667 50 91.667s5.088 -0.258 7.558 -0.763c2.429 -0.504 4.796 -1.238 7.033 -2.188c2.238 -0.946 4.383 -2.108 6.375 -3.458c1.992 -1.342 3.858 -2.883 5.546 -4.579c1.688 -1.688 3.225 -3.554 4.583 -5.55c1.354 -2.013 2.517 -4.158 3.454 -6.367c0.954 -2.25 1.688 -4.617 2.188 -7.05C87.242 59.254 87.5 56.713 87.5 54.167S87.242 49.079 86.738 46.608z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.right-arrow-with-tail {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="black" d="M47.054 72.054l5.892 5.892L80.892 50l-27.946 -27.946l-5.892 5.892L64.942 45.833H25v8.333h39.942z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.right-arrow {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M41.921 79.421L71.338 50 41.921 20.579 33.079 29.421 53.663 50 33.079 70.579z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.right-chevron-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="black" d="M41.921 79.421L71.338 50l-29.417 -29.421l-8.842 8.842L53.663 50l-20.583 20.579z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.right-triangle {
+  color: var(--text-faint);
+  background-color: var(--text-faint);
+  height: 12px;
+  width: 12px;
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 32 32"><path fill="red" stroke-width="2" stroke="currentColor" d="M16 22L6 12l1.4-1.4l8.6 8.6l8.6-8.6L26 12z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.run-command {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="black" stroke-width="2" stroke="currentColor" d="M33.5,16.7c-4.9,0-9.1,3.6-9.9,8.4l-9.1,54.4c-0.2,1,0.1,2,0.7,2.7c0.6,0.7,1.6,1.2,2.5,1.2h70c1.6,0,3-1.2,3.3-2.8 l8.7-52.2c1-6-3.7-11.6-9.9-11.6H33.5z M3.4,36.7c-1.2,0-2.3,0.6-2.9,1.7c-0.6,1-0.6,2.3,0,3.4c0.6,1,1.7,1.7,2.9,1.7h7.7 c1.2,0,2.3-0.6,2.9-1.7c0.6-1,0.6-2.3,0-3.4c-0.6-1-1.7-1.7-2.9-1.7H3.4z M28.5,36.7h63.2l-6.7,40H21.8L28.5,36.7z M39.7,46.7 c-1.6,0-3,1.1-3.3,2.7l-2.7,13.3c-0.2,1,0.1,2,0.7,2.8c0.6,0.8,1.6,1.2,2.6,1.2h36.6c1.6,0,3-1.1,3.3-2.7l2.7-13.3 c0.2-1-0.1-2-0.7-2.8c-0.6-0.8-1.6-1.2-2.6-1.2L39.7,46.7z M3.4,50c-1.2,0-2.3,0.6-2.9,1.7c-0.6,1-0.6,2.3,0,3.4 c0.6,1,1.7,1.7,2.9,1.7H9c1.2,0,2.3-0.6,2.9-1.7c0.6-1,0.6-2.3,0-3.4c-0.6-1-1.7-1.7-2.9-1.7H3.4z M3.4,63.3 c-1.2,0-2.3,0.6-2.9,1.7c-0.6,1-0.6,2.3,0,3.4c0.6,1,1.7,1.7,2.9,1.7H7c1.2,0,2.3-0.6,2.9-1.7c0.6-1,0.6-2.3,0-3.4 c-0.6-1-1.7-1.7-2.9-1.7H3.4z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.search {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M10 18a7.952 7.952 0 0 0 4.897-1.688l4.396 4.396l1.414-1.414l-4.396-4.396A7.952 7.952 0 0 0 18 10c0-4.411-3.589-8-8-8s-8 3.589-8 8s3.589 8 8 8zm0-14c3.309 0 6 2.691 6 6s-2.691 6-6 6s-6-2.691-6-6s2.691-6 6-6z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.sheets-in-box {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="black" d="M75 20.833H25v8.333h50M25 37.5h50v8.333H25m-16.667 4.167h8.333v20.833h66.667v-20.833h8.333v20.833a8.333 8.333 0 0 1 -8.333 8.333H16.667a8.333 8.333 0 0 1 -8.333 -8.333m66.667 -16.667H25v8.333h50z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.spreadsheet {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="black" d="M21 5c0-1.103-.897-2-2-2H5c-1.103 0-2 .897-2 2v14c0 1.103.897 2 2 2h14c1.103 0 2-.897 2-2V5zM5 19V5h14l.002 14H5z"/><path fill="red" d="M7 7h1.998v2H7zm4 0h6v2h-6zm-4 4h1.998v2H7zm4 0h6v2h-6zm-4 4h1.998v2H7zm4 0h6v2h-6z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.stacked-levels {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="black" d="M62.5 12.5a4.167 4.167 0 0 1 4.167 4.167v16.667a4.167 4.167 0 0 1 -4.167 4.167h-8.333v8.333h16.667a4.167 4.167 0 0 1 4.167 4.167v12.5h8.333a4.167 4.167 0 0 1 4.167 4.167v16.667a4.167 4.167 0 0 1 -4.167 4.167h-25a4.167 4.167 0 0 1 -4.167 -4.167v-16.667a4.167 4.167 0 0 1 4.167 -4.167h8.333v-8.333H33.333v8.333h8.333a4.167 4.167 0 0 1 4.167 4.167v16.667a4.167 4.167 0 0 1 -4.167 4.167H16.667a4.167 4.167 0 0 1 -4.167 -4.167v-16.667a4.167 4.167 0 0 1 4.167 -4.167h8.333v-12.5a4.167 4.167 0 0 1 4.167 -4.167h16.667V37.5H37.5a4.167 4.167 0 0 1 -4.167 -4.167V16.667a4.167 4.167 0 0 1 4.167 -4.167h25zM37.5 70.833H20.833v8.333h16.667v-8.333zm41.667 0h-16.667v8.333h16.667v-8.333zM58.333 20.833h-16.667v8.333h16.667V20.833z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.star-list {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M79.167 62.5L79.167 50 70.833 50 70.833 62.5 61.583 62.5 58.333 62.5 58.333 70.833 61.583 70.833 70.833 70.833 70.833 83.333 79.167 83.333 79.167 70.833 87.763 70.833 91.667 70.833 91.667 62.5 87.763 62.5zM16.667 29.167H62.5V37.5H16.667zM16.667 45.833H62.5V54.167H16.667zM16.667 62.5H50V70.833H16.667z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.star {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="black" d="M27.15 59.679l-6.208 26.883a4.158 4.158 0 0 0 6.371 4.404L50 75.842l22.688 15.125a4.171 4.171 0 0 0 6.321 -4.608l-7.621 -26.667l18.9 -17.008a4.167 4.167 0 0 0 -2.458 -7.25l-23.754 -1.892l-10.279 -22.754a4.158 4.158 0 0 0 -7.592 0L35.925 33.542l-23.754 1.888a4.167 4.167 0 0 0 -2.579 7.138l17.558 17.113zm11.888 -18.025a4.158 4.158 0 0 0 3.467 -2.442L50 22.625l7.496 16.588a4.158 4.158 0 0 0 3.467 2.442l16.55 1.313l-13.629 12.267c-1.183 1.067 -1.654 2.708 -1.221 4.242l5.221 18.271l-15.567 -10.379a4.146 4.146 0 0 0 -4.621 0l-16.267 10.846l4.375 -18.942a4.167 4.167 0 0 0 -1.15 -3.917l-12.658 -12.342l17.042 -1.358z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.strikethrough-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M20 11h-8c-4 0-4-1.816-4-2.5C8 7.882 8 6 12 6c2.8 0 2.99 1.678 3 2.014L16 8h1c0-1.384-1.045-4-5-4c-5.416 0-6 3.147-6 4.5c0 .728.148 1.667.736 2.5H4v2h16v-2zm-8 7c-3.793 0-3.99-1.815-4-2H6c0 .04.069 4 6 4c5.221 0 6-2.819 6-4.5c0-.146-.009-.317-.028-.5h-2.006c.032.2.034.376.034.5c0 .684 0 2.5-4 2.5z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.switch {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M41.667 45.833H29.588l0.004 -0.037a20.65 20.65 0 0 1 3.133 -7.446a21.058 21.058 0 0 1 9.167 -7.546c1.258 -0.533 2.571 -0.942 3.908 -1.212a21.158 21.158 0 0 1 8.408 0a20.742 20.742 0 0 1 10.521 5.671l5.9 -5.883a29.317 29.317 0 0 0 -9.267 -6.254a28.838 28.838 0 0 0 -5.479 -1.7a29.496 29.496 0 0 0 -11.746 0a28.917 28.917 0 0 0 -5.483 1.704a29.333 29.333 0 0 0 -12.833 10.558a29.075 29.075 0 0 0 -4.392 10.438c-0.117 0.563 -0.179 1.138 -0.263 1.708H8.333l16.667 16.667l16.667 -16.667zm16.667 8.333h12.079l-0.004 0.033a20.733 20.733 0 0 1 -8.763 13.075a20.596 20.596 0 0 1 -7.446 3.133a21.138 21.138 0 0 1 -8.404 0a20.65 20.65 0 0 1 -7.446 -3.133a21.133 21.133 0 0 1 -3.083 -2.542L29.375 70.625a29.3 29.3 0 0 0 9.271 6.25c1.767 0.75 3.613 1.321 5.479 1.7a29.458 29.458 0 0 0 11.742 0a29.296 29.296 0 0 0 18.313 -12.271a29.058 29.058 0 0 0 4.388 -10.429c0.113 -0.563 0.179 -1.138 0.263 -1.708H91.667l-16.667 -16.667l-16.667 16.667z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.sync-small {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M12 22C6.477 22 2 17.523 2 12S6.477 2 12 2s10 4.477 10 10s-4.477 10-10 10zm3.27-11.25H14a.75.75 0 0 0 0 1.5h2.75a.75.75 0 0 0 .75-.75V8.25a.75.75 0 0 0-1.5 0V9a4.991 4.991 0 0 0-4-2c-1.537 0-2.904.66-3.827 1.77a.75.75 0 0 0 1.154.96C9.963 8.963 10.907 8.5 12 8.5c1.492 0 2.767.934 3.27 2.25zm-7.27 5V15a5.013 5.013 0 0 0 7.821.237a.75.75 0 1 0-1.142-.972a3.513 3.513 0 0 1-5.842-.765H10a.75.75 0 0 0 0-1.5H7.25a.75.75 0 0 0-.75.75v3a.75.75 0 0 0 1.5 0z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.sync {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M16 8.25a.75.75 0 0 1 1.5 0v3.25a.75.75 0 0 1-.75.75H14a.75.75 0 0 1 0-1.5h1.27A3.502 3.502 0 0 0 12 8.5c-1.093 0-2.037.464-2.673 1.23a.75.75 0 1 1-1.154-.96C9.096 7.66 10.463 7 12 7c1.636 0 3.088.785 4 2v-.75zM8 15v.75a.75.75 0 0 1-1.5 0v-3a.75.75 0 0 1 .75-.75H10a.75.75 0 0 1 0 1.5H8.837a3.513 3.513 0 0 0 5.842.765a.75.75 0 1 1 1.142.972A5.013 5.013 0 0 1 8 15zm4-13C6.477 2 2 6.477 2 12s4.477 10 10 10s10-4.477 10-10S17.523 2 12 2zm8.5 10a8.5 8.5 0 1 1-17 0a8.5 8.5 0 0 1 17 0z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.tag-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M66.742 15.896L63.467 33.333h-20.692l2.983 -15.896L37.575 15.896L34.3 33.333H16.667v8.333h16.071l-3.129 16.667H12.5v8.333h15.546l-2.975 15.854l8.188 1.538L36.525 66.667h20.692l-2.975 15.854l8.188 1.538L65.692 66.667H83.333v-8.333h-16.079l3.129 -16.667H87.5V33.333h-15.554l2.983 -15.896L66.742 15.896zM58.775 58.333H38.088l3.129 -16.667h20.692L58.775 58.333z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.three-horizontal-bars {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="black" d="M16.667 25h66.667v8.333H16.667zm0 20.833h66.667v8.333H16.667zm0 20.833h66.667v8.333H16.667z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.trash {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="black" d="M37.5 12.5v4.167H16.667v8.333h4.167v54.167a8.333 8.333 0 0 0 8.333 8.333h41.667a8.333 8.333 0 0 0 8.333 -8.333V25h4.167V16.667h-20.833V12.5H37.5M29.167 25h41.667v54.167H29.167V25m8.333 8.333v37.5h8.333V33.333H37.5m16.667 0v37.5h8.333V33.333h-8.333z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.undo-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M37.5 41.667h25c6.892 0 12.5 5.608 12.5 12.5s-5.608 12.5 -12.5 12.5h-12.5v8.333h12.5c11.488 0 20.833 -9.346 20.833 -20.833s-9.346 -20.833 -20.833 -20.833H37.5V20.833L16.667 37.5l20.833 16.667V41.667z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.unindent-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M16.667 25H25V75H16.667zM59.554 22.054L31.608 50 59.554 77.946 65.446 72.054 47.558 54.167 83.333 54.167 83.333 45.833 47.558 45.833 65.446 27.946z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.up-and-down-arrows {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="black" d="M49.792 33.125l-5.892 5.892L33.333 28.45V83.333H25V28.45L14.438 39.017L8.542 33.125L29.167 12.5l20.625 20.625zm41.667 33.75L70.833 87.5l-20.625 -20.625l5.892 -5.892l10.571 10.567L66.667 16.667h8.333v54.883l10.567 -10.567l5.892 5.892z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.up-arrow-with-tail {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="black" d="M45.833 35.058V75h8.333V35.058l17.888 17.888l5.892 -5.892L50 19.108l-27.946 27.946l5.892 5.892z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.up-chevron-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="black" d="M26.221 55.388l5.892 5.892L50 43.392l17.888 17.888l5.892 -5.892L50 31.608z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.vault {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="black" d="M75 83.333H25v8.333H16.667v-8.333H12.5a4.167 4.167 0 0 1 -4.167 -4.167V16.667a4.167 4.167 0 0 1 4.167 -4.167h75a4.167 4.167 0 0 1 4.167 4.167v62.5a4.167 4.167 0 0 1 -4.167 4.167h-4.167v8.333h-8.333v-8.333zM16.667 75h66.667V20.833H16.667v54.167zm37.5 -17.192V70.833h-8.333v-13.025A16.675 16.675 0 0 1 50 25a16.667 16.667 0 0 1 4.167 32.808zM50 50a8.333 8.333 0 1 0 0 -16.667a8.333 8.333 0 0 0 0 16.667z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.vertical-split {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M75 66.667v-12.5h-12.5v37.5h-8.333V8.333h8.333v37.5h12.5V33.333l16.667 16.667l-16.667 16.667M8.333 50l16.667 16.667v-12.5h12.5v37.5h8.333V8.333H37.5v37.5H25V33.333l-16.667 16.667z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.vertical-three-dots {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M50 41.667c-4.583 0 -8.333 3.75 -8.333 8.333s3.75 8.333 8.333 8.333s8.333 -3.75 8.333 -8.333s-3.75 -8.333 -8.333 -8.333zm0 -25c-4.583 0 -8.333 3.75 -8.333 8.333s3.75 8.333 8.333 8.333s8.333 -3.75 8.333 -8.333s-3.75 -8.333 -8.333 -8.333zm0 50c-4.583 0 -8.333 3.75 -8.333 8.333s3.75 8.333 8.333 8.333s8.333 -3.75 8.333 -8.333s-3.75 -8.333 -8.333 -8.333z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.wrench-screwdriver-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M18 1.83c-.5 0-1 .17-1.41.58L8 11l1.5 1.5L6 16H4l-2 4l2 2l4-2v-2l3.5-3.5L13 16l8.59-8.59c.62-.91.78-2.04 0-2.82l-2.18-2.18A1.95 1.95 0 0 0 18 1.83M18 4l2 2l-7 7l-2-2l7-7z"></path></svg>');
+}
+/*
+body:not(.no-svg-replace) svg.command-glyph{
+-webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M50 58.333H75V66.667H50zM26.221 40.446L35.775 50 26.221 59.554 32.113 65.446 47.558 50 32.113 34.554z M83.333 16.667H16.667C12.071 16.667 8.333 20.404 8.333 25v50c0 4.596 3.738 8.333 8.333 8.333h66.667c4.596 0 8.333 -3.738 8.333 -8.333V25C91.667 20.404 87.929 16.667 83.333 16.667zM16.667 75V25h66.667l0.008 50H16.667z"></path></svg>');
+}*/
+body:not(.no-svg-replace) svg.add-note-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M5 19V5h7v7h7v1c.7 0 1.37.13 2 .35V9l-6-6H5c-1.11 0-2 .89-2 2v14a2 2 0 0 0 2 2h8.35c-.22-.63-.35-1.3-.35-2H5m9-14.5l5.5 5.5H14V4.5M23 18v2h-3v3h-2v-3h-3v-2h3v-3h2v3h3z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.calendar-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M29.167 45.833H37.5V54.167H29.167zM29.167 62.5H37.5V70.833H29.167zM45.833 45.833H54.167V54.167H45.833zM45.833 62.5H54.167V70.833H45.833zM62.5 45.833H70.833V54.167H62.5zM62.5 62.5H70.833V70.833H62.5z M20.833 91.667h58.333c4.596 0 8.333 -3.738 8.333 -8.333V33.333V25c0 -4.596 -3.738 -8.333 -8.333 -8.333h-8.333V8.333h-8.333v8.333H37.5V8.333H29.167v8.333H20.833C16.238 16.667 12.5 20.404 12.5 25v8.333v50C12.5 87.929 16.238 91.667 20.833 91.667zM79.167 33.333l0.004 50H20.833V33.333H79.167z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.duplicate-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M45.833 41.667L37.5 41.667 37.5 54.167 25 54.167 25 62.5 37.5 62.5 37.5 75 45.833 75 45.833 62.5 58.333 62.5 58.333 54.167 45.833 54.167z M16.667 91.667h50c4.596 0 8.333 -3.738 8.333 -8.333V33.333c0 -4.596 -3.738 -8.333 -8.333 -8.333H16.667C12.071 25 8.333 28.738 8.333 33.333v50C8.333 87.929 12.071 91.667 16.667 91.667zM16.667 33.333h50l0.008 50H16.667V33.333z M83.333 8.333H33.333v8.333h50v50h8.333V16.667C91.667 12.071 87.929 8.333 83.333 8.333z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.file-explorer-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M12.5 12.467C12.5 10.183 14.354 8.333 16.637 8.333h66.725a4.167 4.167 0 0 1 4.138 4.133v75.067a4.138 4.138 0 0 1 -4.138 4.133H16.637A4.167 4.167 0 0 1 12.5 87.533V12.467zM79.167 45.833V16.667H20.833v29.167h58.333zm0 8.333H20.833v29.167h58.333v-29.167zM37.5 25h25v8.333H37.5V25zm0 37.5h25v8.333H37.5v-8.333z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.graph-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M19.5 3A2.502 2.502 0 0 0 17 5.5c0 .357.078.696.214 1.005l-1.955 2.199A3.977 3.977 0 0 0 13 8c-.74 0-1.424.216-2.019.566L8.707 6.293l-.023.023C8.88 5.918 9 5.475 9 5a3 3 0 1 0-3 3c.475 0 .917-.12 1.316-.316l-.023.023L9.567 9.98A3.956 3.956 0 0 0 9 12c0 .997.38 1.899.985 2.601l-2.577 2.576A2.472 2.472 0 0 0 6.5 17C5.122 17 4 18.121 4 19.5S5.122 22 6.5 22S9 20.879 9 19.5c0-.321-.066-.626-.177-.909l2.838-2.838c.421.15.867.247 1.339.247c2.206 0 4-1.794 4-4c0-.636-.163-1.229-.428-1.764l2.117-2.383c.256.088.526.147.811.147C20.879 8 22 6.879 22 5.5S20.879 3 19.5 3zM13 14c-1.103 0-2-.897-2-2s.897-2 2-2s2 .897 2 2s-.897 2-2 2z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.import-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M50 75L66.667 54.167 54.167 54.167 54.167 8.333 45.833 8.333 45.833 54.167 33.333 54.167z M79.167 37.5h-16.667v8.333h16.667v37.5H20.833v-37.5h16.667V37.5H20.833c-4.596 0 -8.333 3.738 -8.333 8.333v37.5c0 4.596 3.738 8.333 8.333 8.333h58.333c4.596 0 8.333 -3.738 8.333 -8.333v-37.5C87.5 41.238 83.763 37.5 79.167 37.5z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.languages {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M77.083 41.667l18.333 45.833h-8.979l-5.004 -12.5h-17.042l-4.996 12.5h-8.975L68.75 41.667h8.333zM41.667 8.333v8.333h25v8.333h-8.2a75.925 75.925 0 0 1 -15.083 26.254 61.933 61.933 0 0 0 9.733 7.113l-3.129 7.825A70.896 70.896 0 0 1 37.5 57.188a69.483 69.483 0 0 1 -25.837 14.783l-2.233 -8.038a61.25 61.25 0 0 0 22.196 -12.675A75.325 75.325 0 0 1 19.863 33.333h9.333A66.8 66.8 0 0 0 37.5 45.321a67.354 67.354 0 0 0 12.125 -20.317L8.333 25V16.667h25V8.333h8.333zm31.25 45.354L67.721 66.667h10.383L72.917 53.688z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.links-coming-in {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M76.5 64.75l-5.833 -5.917 5.833 -5.917A20.833 20.833 0 1 0 47.167 23.333v0l-5.917 5.917 -5.917 -5.917 5.917 -5.917a29.167 29.167 0 1 1 41.667 41.25h0l-5.917 5.917ZM64.75 76.5l-5.917 5.917A29.167 29.167 0 0 1 17.583 41.167l5.917 -5.917 5.917 5.917 -5.917 5.917A20.833 20.833 0 1 0 52.833 76.667v0l5.917 -5.833 5.917 5.833Zm-3 -44.167 5.917 5.917L38.25 67.667l-5.917 -5.917L61.75 32.333Z M79.917 85.25H83.333a13.667 13.667 0 0 1 12.167 7.667V91.667A15.583 15.583 0 0 0 79.917 75.667v-8.333L64.75 80.417l15.167 12.833Z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.links-going-out {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M76.5 64.75l-5.833 -5.917 5.833 -5.917A20.833 20.833 0 1 0 47.167 23.333v0l-5.917 5.917 -5.917 -5.917 5.917 -5.917a29.167 29.167 0 1 1 41.667 41.25h0l-5.917 5.917ZM64.75 76.5l-5.917 5.917A29.167 29.167 0 0 1 17.583 41.167l5.917 -5.917 5.917 5.917 -5.917 5.917A20.833 20.833 0 1 0 52.833 76.667v0l5.917 -5.833 5.917 5.833Zm-3 -44.167 5.917 5.917L38.25 67.667l-5.917 -5.917L61.75 32.333Z M79.917 85.25H76.917a13.667 13.667 0 0 0 -12.167 7.667V91.667A15.583 15.583 0 0 1 79.917 75.667v-8.333l15.167 12.75L79.917 93.25Z"></path></svg>');
+}
+/*
+body:not(.no-svg-replace) svg.merge-files-glyph{
+-webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M87.5 31.417H68.583V12.5a4.167 4.167 0 0 0 -4.167 -4.167H12.5A4.167 4.167 0 0 0 8.333 12.5V64.417a4.167 4.167 0 0 0 4.167 4.167H31.417V87.5a4.167 4.167 0 0 0 4.167 4.167H87.5a4.167 4.167 0 0 0 4.167 -4.167V35.583A4.167 4.167 0 0 0 87.5 31.417ZM83.333 83.333H39.75V64.417a4.167 4.167 0 0 0 -4.167 -4.167H16.667V16.667H60.25V35.583a4.167 4.167 0 0 0 4.167 4.167H83.333Z"></path></svg>');
+}*/
+body:not(.no-svg-replace) svg.merge-files {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M10.417 77.083C10.417 85.125 16.958 91.667 25 91.667s14.583 -6.542 14.583 -14.583c0 -6.583 -4.417 -12.096 -10.417 -13.904v-14.533c1.017 1.138 2.121 2.196 3.388 3.1c4.917 3.517 10.904 4.575 16.325 4.575c4.025 0 7.721 -0.583 10.442 -1.171a14.583 14.583 0 0 0 13.6 9.438c8.042 0 14.583 -6.542 14.583 -14.583s-6.542 -14.583 -14.583 -14.583a14.583 14.583 0 0 0 -14.183 11.325c-5.404 1.338 -15.267 2.567 -21.329 -1.775c-2.775 -1.988 -4.542 -5.163 -5.442 -9.317C36.479 33.167 39.583 28.421 39.583 22.917C39.583 14.875 33.042 8.333 25 8.333S10.417 14.875 10.417 22.917c0 6.583 4.417 12.096 10.417 13.904v26.358c-6 1.808 -10.417 7.321 -10.417 13.904zm62.5 -33.333c3.446 0 6.25 2.804 6.25 6.25s-2.804 6.25 -6.25 6.25S66.667 53.446 66.667 50s2.804 -6.25 6.25 -6.25zm-41.667 33.333c0 3.446 -2.804 6.25 -6.25 6.25s-6.25 -2.804 -6.25 -6.25S21.554 70.833 25 70.833s6.25 2.804 6.25 6.25zm-12.5 -54.167C18.75 19.471 21.554 16.667 25 16.667s6.25 2.804 6.25 6.25S28.446 29.167 25 29.167s-6.25 -2.804 -6.25 -6.25z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.open-elsewhere-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M83.333 12.5H16.667C12.071 12.5 8.333 16.238 8.333 20.833v58.333c0 4.596 3.738 8.333 8.333 8.333h20.833v-8.333H16.667V29.167h66.667v50h-20.833v8.333h20.833c4.596 0 8.333 -3.738 8.333 -8.333V20.833C91.667 16.238 87.929 12.5 83.333 12.5z M54.167 87.5L54.167 66.667 66.667 66.667 50 45.833 33.333 66.667 45.833 66.667 45.833 87.5z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.paper-plane-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M85.679 13.917c-1.217 -0.829 -2.779 -0.954 -4.121 -0.329l-70.833 33.333C9.246 47.621 8.313 49.117 8.333 50.75c0.025 1.633 1 3.104 2.5 3.758L33.333 64.354v28.008l24.317 -17.367l19.85 8.683c0.533 0.238 1.104 0.35 1.667 0.35c0.754 0 1.5 -0.204 2.167 -0.608c1.158 -0.704 1.904 -1.929 1.996 -3.283l4.167 -62.5C87.588 16.163 86.9 14.75 85.679 13.917zM75.404 73.667l-21.954 -9.608L66.667 38.196l-31.871 17.708l-12.217 -5.346L78.708 24.142L75.404 73.667z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.paste-text {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M83.333 45.833V20.833c0 -4.596 -3.738 -8.333 -8.333 -8.333h-12.5a4.167 4.167 0 0 0 -4.167 -4.167H33.333a4.167 4.167 0 0 0 -4.167 4.167H16.667c-4.596 0 -8.333 3.738 -8.333 8.333v54.167c0 4.596 3.738 8.333 8.333 8.333h29.167c0 4.596 3.738 8.333 8.333 8.333h29.167c4.596 0 8.333 -3.738 8.333 -8.333v-29.167c0 -4.596 -3.738 -8.333 -8.333 -8.333zm-37.5 8.333v20.833H16.667V20.833h12.5v8.333h33.333V20.833h12.5v25h-20.833c-4.596 0 -8.333 3.738 -8.333 8.333zm8.333 29.167v-29.167h29.167l0.004 29.167H54.167z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.paste {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M79.167 12.5h-9.375a4.167 4.167 0 0 0 -4.167 -4.167h-31.25a4.167 4.167 0 0 0 -4.167 4.167H20.833c-4.596 0 -8.333 3.738 -8.333 8.333v62.5c0 4.596 3.738 8.333 8.333 8.333h58.333c4.596 0 8.333 -3.738 8.333 -8.333V20.833c0 -4.596 -3.738 -8.333 -8.333 -8.333zm0 70.833H20.833V20.833h8.333v8.333h41.667V20.833h8.333v62.5z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.percent-sign-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 256 256"><path fill="red" d="M208.485 64.485l-144 144a12 12 0 0 1-16.97-16.97l144-144a12 12 0 0 1 16.97 16.97zm-160.77 39.8A40.046 40.046 0 1 1 76 115.98a39.738 39.738 0 0 1-28.284-11.697zM60 76a15.987 15.987 0 1 0 4.687-11.314A15.894 15.894 0 0 0 60 76zm160 104a40 40 0 1 1-11.716-28.284A39.735 39.735 0 0 1 220 180zm-24 0a15.893 15.893 0 0 0-4.687-11.313v-.001A16 16 0 1 0 196 180z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.play-audio-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M12 22C6.477 22 2 17.523 2 12S6.477 2 12 2s10 4.477 10 10s-4.477 10-10 10zm0-2a8 8 0 1 0 0-16a8 8 0 0 0 0 16zM10.622 8.415l4.879 3.252a.4.4 0 0 1 0 .666l-4.88 3.252a.4.4 0 0 1-.621-.332V8.747a.4.4 0 0 1 .622-.332z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.plus-minus-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M11 4v5H6v2h5v5h2v-5h5V9h-5V4h-2M6 18v2h12v-2H6z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.presentation-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M83.333 12.5H16.667C12.071 12.5 8.333 16.238 8.333 20.833v41.667c0 4.596 3.738 8.333 8.333 8.333h29.167v12.5H33.333v8.333h12.5h8.333h12.5v-8.333h-12.5v-12.5h29.167c4.596 0 8.333 -3.738 8.333 -8.333V20.833C91.667 16.238 87.929 12.5 83.333 12.5zM16.667 62.5V20.833h66.667l0.004 41.667H16.667z M41.667 54.167L62.5 41.667 41.667 29.167z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.question-mark-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path stroke-width=".5" stroke="currentColor" fill="red" d="M12 19a1.5 1.5 0 1 1-.001 3.001A1.5 1.5 0 0 1 12 19zm0-17a6 6 0 0 1 6 6c0 2.165-.753 3.29-2.674 4.923C13.399 14.56 13 15.297 13 17h-2c0-2.474.787-3.695 3.031-5.601C15.548 10.11 16 9.434 16 8c0-2.21-1.79-4-4-4S8 5.79 8 8v1H6V8a6 6 0 0 1 6-6z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.restore-file-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M13 3a9 9 0 0 0-9 9H1l4 3.99L9 12H6c0-3.87 3.13-7 7-7s7 3.13 7 7s-3.13 7-7 7c-1.93 0-3.68-.79-4.94-2.06l-1.42 1.42A8.954 8.954 0 0 0 13 21a9 9 0 0 0 0-18zm-1 5v5l4.25 2.52l.77-1.28l-3.52-2.09V8z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.scissors-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M9.683 7.562L12 9.88l6.374-6.375a2 2 0 0 1 2.829 0l.707.707L9.683 16.438a4 4 0 1 1-2.121-2.121L9.88 12L7.562 9.683a4 4 0 1 1 2.121-2.121zM6 8a2 2 0 1 0 0-4a2 2 0 0 0 0 4zm0 12a2 2 0 1 0 0-4a2 2 0 0 0 0 4zm9.535-6.587l6.375 6.376l-.707.707a2 2 0 0 1-2.829 0l-4.96-4.961l2.12-2.122z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.scissors {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M9.683 7.562L12 9.88l6.374-6.375a2 2 0 0 1 2.829 0l.707.707L9.683 16.438a4 4 0 1 1-2.121-2.121L9.88 12L7.562 9.683a4 4 0 1 1 2.121-2.121zM6 8a2 2 0 1 0 0-4a2 2 0 0 0 0 4zm0 12a2 2 0 1 0 0-4a2 2 0 0 0 0 4zm9.535-6.587l6.375 6.376l-.707.707a2 2 0 0 1-2.829 0l-4.96-4.961l2.12-2.122z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.search-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M10 18a7.952 7.952 0 0 0 4.897-1.688l4.396 4.396l1.414-1.414l-4.396-4.396A7.952 7.952 0 0 0 18 10c0-4.411-3.589-8-8-8s-8 3.589-8 8s3.589 8 8 8zm0-14c3.309 0 6 2.691 6 6s-2.691 6-6 6s-6-2.691-6-6s2.691-6 6-6z"/><path fill="red" d="M11.412 8.586c.379.38.588.882.588 1.414h2a3.977 3.977 0 0 0-1.174-2.828c-1.514-1.512-4.139-1.512-5.652 0l1.412 1.416c.76-.758 2.07-.756 2.826-.002z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.select-all-text {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M12.5 4.167h8.333v8.333H12.5v8.333H4.167V12.5a8.333 8.333 0 0 1 8.333 -8.333m45.833 0a8.333 8.333 0 0 1 8.333 8.333v8.333h-8.333V12.5h-8.333V4.167h8.333m25 25a8.333 8.333 0 0 1 8.333 8.333v8.333h-8.333V37.5h-8.333V29.167h8.333m8.333 54.167a8.333 8.333 0 0 1 -8.333 8.333h-8.333v-8.333h8.333v-8.333h8.333v8.333m-8.333 -29.167h8.333v12.5h-8.333v-12.5m-29.167 -16.667V29.167h12.5v12.5h-8.333V37.5h-4.167m0 54.167v-8.333h12.5v8.333h-12.5m-16.667 0a8.333 8.333 0 0 1 -8.333 -8.333v-8.333h8.333v8.333h8.333v8.333H37.5m-8.333 -25v-12.5h8.333v4.167h4.167v8.333H29.167M29.167 12.5V4.167h12.5v8.333H29.167M12.5 66.667a8.333 8.333 0 0 1 -8.333 -8.333v-8.333h8.333v8.333h8.333v8.333H12.5M4.167 29.167h8.333v12.5H4.167V29.167m33.333 0h8.333v8.333H37.5v8.333H29.167V37.5a8.333 8.333 0 0 1 8.333 -8.333m29.167 29.167a8.333 8.333 0 0 1 -8.333 8.333h-8.333v-8.333h8.333v-8.333h8.333v8.333z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.split {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M61.875 20.208l6 6 -12 12 5.917 5.917 12 -12 6 6c1.292 1.292 3.542 0.375 3.542 -1.5V18.75c0 -1.167 -0.917 -2.083 -2.083 -2.083h-17.875c-1.875 0 -2.792 2.25 -1.5 3.542zM36.625 16.667H18.75c-1.167 0 -2.083 0.917 -2.083 2.083v17.875c0 1.875 2.25 2.792 3.542 1.458L26.208 32.083 45.833 51.667V79.167c0 2.292 1.875 4.167 4.167 4.167s4.167 -1.875 4.167 -4.167v-29.167c0 -1.083 -0.458 -2.167 -1.208 -2.958l-20.833 -20.875 6 -6c1.292 -1.25 0.375 -3.5 -1.5 -3.5z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.star-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M91.446 38.246c-0.538 -1.575 -1.958 -2.688 -3.617 -2.817L64.075 33.542l-10.279 -22.754C53.125 9.292 51.638 8.333 50 8.333s-3.125 0.958 -3.796 2.45L35.925 33.542L12.171 35.429C10.542 35.558 9.138 36.629 8.583 38.167s-0.163 3.258 1.008 4.4l17.554 17.113l-6.208 26.883c-0.383 1.663 0.288 3.392 1.692 4.362C23.346 91.417 24.171 91.667 25 91.667c0.804 0 1.613 -0.233 2.313 -0.7L50 75.842l22.688 15.125c1.45 0.967 3.354 0.929 4.771 -0.1c1.408 -1.029 2.029 -2.833 1.55 -4.508l-7.621 -26.667l18.9 -17.008C91.525 41.567 91.979 39.825 91.446 38.246z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.stop-audio-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M50 8.333C27.025 8.333 8.333 27.025 8.333 50s18.692 41.667 41.667 41.667s41.667 -18.692 41.667 -41.667S72.975 8.333 50 8.333zM50 83.333c-18.379 0 -33.333 -14.954 -33.333 -33.333s14.954 -33.333 33.333 -33.333s33.333 14.954 33.333 33.333S68.379 83.333 50 83.333z M37.5 37.5H62.5V62.5H37.5z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.sweep {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M22.452 1.923a.75.75 0 0 1 0 1.06l-6.928 6.929a5.751 5.751 0 0 1-.496 7.567l-.832.832l-2.787 4.18a.75.75 0 0 1-1.154.115L1.769 14.12a.75.75 0 0 1 .115-1.154l4.18-2.787l.832-.832a5.751 5.751 0 0 1 7.567-.496l6.929-6.928a.75.75 0 0 1 1.06 0zM7.603 10.762l6.01 6.01l.354-.353a4.25 4.25 0 0 0-6.01-6.01l-.354.353zm-1.156.965l-2.97 1.98l7.191 7.191l1.98-2.97l-6.201-6.201z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.two-blank-pages {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M83.333 8.333H41.667c-4.596 0 -8.333 3.738 -8.333 8.333v16.667H16.667c-4.596 0 -8.333 3.738 -8.333 8.333v41.667c0 4.596 3.738 8.333 8.333 8.333h41.667c4.596 0 8.333 -3.738 8.333 -8.333v-16.667h16.667c4.596 0 8.333 -3.738 8.333 -8.333V16.667c0 -4.596 -3.738 -8.333 -8.333 -8.333zM16.667 83.333V41.667h41.667l0.008 41.667H16.667zm66.667 -25h-16.667v-16.667c0 -4.596 -3.738 -8.333 -8.333 -8.333h-16.667V16.667h41.667v41.667z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.tomorrow-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M33.333 62.5L45.833 62.5 45.833 75 54.167 75 54.167 62.5 66.667 62.5 66.667 54.167 54.167 54.167 54.167 41.667 45.833 41.667 45.833 54.167 33.333 54.167z M79.167 16.667h-8.333V8.333h-8.333v8.333H37.5V8.333H29.167v8.333H20.833C16.238 16.667 12.5 20.404 12.5 25v8.333v50c0 4.596 3.738 8.333 8.333 8.333h58.333c4.596 0 8.333 -3.738 8.333 -8.333V33.333V25C87.5 20.404 83.763 16.667 79.167 16.667zM79.175 83.333H20.833V33.333h58.333L79.175 83.333z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.yesterday-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M33.333 54.167H66.667V62.5H33.333z M79.167 16.667h-8.333V8.333h-8.333v8.333H37.5V8.333H29.167v8.333H20.833C16.238 16.667 12.5 20.404 12.5 25v8.333v50c0 4.596 3.738 8.333 8.333 8.333h58.333c4.596 0 8.333 -3.738 8.333 -8.333V33.333V25C87.5 20.404 83.763 16.667 79.167 16.667zM79.175 83.333H20.833V33.333h58.333L79.175 83.333z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.workspace-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 512 512"><path fill="red" stroke-width="10" stroke="currentColor" d="M472 232h-48V120a24.028 24.028 0 0 0-24-24H40a24.028 24.028 0 0 0-24 24v246a24.028 24.028 0 0 0 24 24h172v50h-60v32h152v-32h-60v-50h92v58a24.027 24.027 0 0 0 24 24h112a24.027 24.027 0 0 0 24-24V256a24.027 24.027 0 0 0-24-24zm-136 24v102H48V128h344v104h-32a24.027 24.027 0 0 0-24 24zm128 184h-96V264h96z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.box-glyph {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path d="M5 9v10h14.002L19 9H5zm11 4H8v-2h8v2zm4.002-6L20 5H4v2h16z"/><path fill="red" d="M20 3H4c-1.103 0-2 .897-2 2v2c0 .736.405 1.375 1 1.722V19c0 1.103.897 2 2 2h14c1.103 0 2-.897 2-2V8.722c.595-.347 1-.986 1-1.722V5c0-1.103-.897-2-2-2zM4 5h16l.002 2H4V5zm1 14V9h14l.002 10H5z"/><path fill="red" d="M8 11h8v2H8z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.wand {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M11 4l-.5-1l-.5 1l-1 .125l.834.708L9.5 6l1-.666l1 .666l-.334-1.167l.834-.708zm8.334 10.666L18.5 13l-.834 1.666l-1.666.209l1.389 1.181L16.834 18l1.666-1.111L20.166 18l-.555-1.944L21 14.875zM6.667 6.333L6 5l-.667 1.333L4 6.5l1.111.944L4.667 9L6 8.111L7.333 9l-.444-1.556L8 6.5zM3.414 17c0 .534.208 1.036.586 1.414L5.586 20c.378.378.88.586 1.414.586s1.036-.208 1.414-.586L20 8.414c.378-.378.586-.88.586-1.414S20.378 5.964 20 5.586L18.414 4c-.756-.756-2.072-.756-2.828 0L4 15.586c-.378.378-.586.88-.586 1.414zM17 5.414L18.586 7L15 10.586L13.414 9L17 5.414z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.longform {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M21 4H7a2 2 0 1 0 0 4h14v13a1 1 0 0 1-1 1H7a4 4 0 0 1-4-4V6a4 4 0 0 1 4-4h13a1 1 0 0 1 1 1v1zM5 18a2 2 0 0 0 2 2h12V10H7a3.982 3.982 0 0 1-2-.535V18zM20 7H7a1 1 0 1 1 0-2h13v2z"></path></svg>');
+}
+body:not(.no-svg-replace) svg.changelog {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path d="M12 2C6.486 2 2 6.486 2 12s4.486 10 10 10s10-4.486 10-10S17.514 2 12 2zm0 18c-4.411 0-8-3.589-8-8s3.589-8 8-8s8 3.589 8 8s-3.589 8-8 8z" fill="currentColor"/><path d="M11 11h2v6h-2zm0-4h2v2h-2z" fill="currentColor"/></svg>');
+}
+
+/*----------------------------------------------------------------
+FOLDS (credits to @mgmeyers for this)
+----------------------------------------------------------------*/
+
+.markdown-preview-view div.is-collapsed h1::after,
+.markdown-preview-view div.is-collapsed h2::after,
+.markdown-preview-view div.is-collapsed h3::after,
+.markdown-preview-view div.is-collapsed h4::after,
+.markdown-preview-view div.is-collapsed h5::after,
+.markdown-preview-view div.is-collapsed h6::after,
+.markdown-preview-view ol .is-collapsed::after,
+.markdown-preview-view ul .is-collapsed:not(.task-list-item)::after,
+.markdown-preview-view ul.contains-task-list li .is-collapsed::after {
+  content: "...";
+  font-family: sans-serif;
+  font-size: 0.9rem;
+  font-weight: 600;
+  padding-left: 3px;
+  color: inherit;
+}
+
+.CodeMirror-foldmarker:after {
+  transition: color 100ms ease;
+}
+
+.is-mobile
+  .markdown-preview-view
+  .frontmatter-collapse-indicator.collapse-indicator {
+  margin-top: 0.3rem;
+}
+
+body:not(.no-svg-replace)
+  .markdown-preview-view
+  .is-collapsed
+  .collapse-indicator
+  > svg.right-triangle {
+  transform: translateY(-15%) rotate(-90deg);
+}
+
+body:not(.no-svg-replace)
+  .markdown-preview-view
+  .collapse-indicator
+  > svg.right-triangle {
+  left: -2.33rem;
+  top: 50%;
+  background-color: var(--text-faint);
+  transform: translateY(-15%);
+}
+
+/*desktop*/
+
+.frontmatter-collapse-indicator {
+  position: relative;
+  cursor: pointer;
+  margin: 0;
+  float: none;
+  padding: 0;
+  display: inline;
+  line-height: inherit;
+  font-size: unset;
+  width: 0;
+  height: 0.5em;
+}
+
+.markdown-preview-view .frontmatter-collapse-indicator {
+  left: calc(-2.2rem) !important;
+  top: -0.75em;
+}
+
+/*collapse icon in <summary> tag*/
+
+summary {
+  list-style: none;
+  cursor: pointer;
+}
+
+summary::-webkit-details-marker {
+  display: none;
+}
+
+details summary:not(.admonition-title)::before {
+  width: 2em;
+  height: 2em;
+  content: "☐";
+  font-size: 9px;
+  cursor: pointer;
+  margin-right: 5px;
+  display: inline-block;
+  vertical-align: -0.3em;
+  background-color: currentColor;
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="black" d="M10.707 17.707L16.414 12l-5.707-5.707l-1.414 1.414L13.586 12l-4.293 4.293z"></path></svg>');
+}
+
+details[open] summary:not(.admonition-title)::before {
+  transform: rotate(90deg);
+}
+
+/*collapse icon in panes*/
+
+.collapse-icon:hover {
+  color: var(--text-normal);
+}
+
+.collapse-icon {
+  cursor: pointer;
+  transition: 250ms ease-in-out;
+}
+
+body:not(.no-svg-replace) .tree-item-self .tree-item-icon > svg.right-triangle {
+  height: 11px;
+  width: 11px;
+  fill: var(--text-muted);
+}
+
+/*collapse icon in workspace*/
+
+body:not(.no-svg-replace) .frontmatter-collapse-indicator svg.right-triangle {
+  background-color: currentColor;
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 32 32"><path fill="red" stroke-width="2" stroke="currentColor" d="M16 22L6 12l1.4-1.4l8.6 8.6l8.6-8.6L26 12z"></path></svg>');
+}
+
+body:not(.no-svg-replace) span[title="Fold line"],
+body:not(.no-svg-replace) span[title="Unfold line"] {
+  position: relative;
+  font-size: 0;
+  color: transparent;
+  display: flex;
+  height: auto;
+  align-items: center;
+}
+
+body:not(.no-svg-replace) span[title="Fold line"]:hover,
+body:not(.no-svg-replace) span[title="Unfold line"]:hover,
+body:not(.no-svg-replace) .CodeMirror-foldgutter-open:hover,
+body:not(.no-svg-replace) .CodeMirror-foldgutter-folded:hover {
+  color: var(--text-muted);
+}
+
+body:not(.no-svg-replace) span[title="Fold line"]:after,
+body:not(.no-svg-replace) span[title="Unfold line"]:after,
+body:not(.no-svg-replace) .CodeMirror-foldgutter-open:after,
+body:not(.no-svg-replace) .CodeMirror-foldgutter-folded:after {
+  text-align: center;
+  color: var(--text-faint);
+  font-size: 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 0px;
+  width: 1rem;
+  height: 1rem;
+}
+
+body:not(.is-mobile):not(.no-svg-replace) span[title="Fold line"]:after,
+body:not(.is-mobile):not(.no-svg-replace) span[title="Unfold line"]:after,
+body:not(.is-mobile):not(.no-svg-replace) .CodeMirror-foldgutter-open:after,
+body:not(.is-mobile):not(.no-svg-replace) .CodeMirror-foldgutter-folded:after {
+  margin-top: 0.35rem;
+  margin-left: 2px;
+}
+
+body:not(.no-svg-replace) .is-mobile .ͼ1 .cm-lineNumbers .cm-gutterElement {
+  padding: 0 3px 0 0px;
+  min-width: 15px;
+  text-align: right;
+  white-space: nowrap;
+}
+
+body:not(.no-svg-replace) span[title="Fold line"]:after,
+body:not(.no-svg-replace) span[title="Unfold line"]:after {
+  font-size: 1rem;
+  line-height: 1;
+}
+
+body:not(.no-svg-replace) span[title="Fold line"]:after,
+body:not(.no-svg-replace) span[title="Unfold line"]:after {
+  font-size: 1rem;
+  line-height: 1;
+}
+
+body:not(.no-svg-replace) span[title="Unfold line"]:after,
+body:not(.no-svg-replace) .CodeMirror-foldgutter-folded:after {
+  background-color: currentColor;
+  background-color: var(--text-faint);
+  height: 12px;
+  width: 12px;
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 32 32"><path fill="red" stroke-width="2" stroke="currentColor" d="M16 22L6 12l1.4-1.4l8.6 8.6l8.6-8.6L26 12z"></path></svg>');
+  transform: translateY(-2px);
+  transform: rotate(-90deg);
+}
+
+body:not(.no-svg-replace) span[title="Fold line"]:after,
+body:not(.no-svg-replace) .CodeMirror-foldgutter-open:after {
+  background-color: currentColor;
+  height: 12px;
+  width: 12px;
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 32 32"><path fill="red" stroke-width="2" stroke="currentColor" d="M16 22L6 12l1.4-1.4l8.6 8.6l8.6-8.6L26 12z"></path></svg>');
+}
+
+.is-mobile span[title="Fold line"]:after,
+.is-mobile .CodeMirror-foldgutter-open:after {
+  transform: translateX(-2px) !important;
+}
+
+/*LINE NUMBER + GUTTER*/
+
+.cm-s-obsidian .CodeMirror-linenumber {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--text-muted);
+  font-family: var(--font-monospace);
+}
+
+.cm-s-obsidian .CodeMirror-activeline-gutter > .CodeMirror-linenumber {
+  font-weight: 600;
+  color: var(--interactive-accent);
+}
+
+/*STYLE SETTINGS*/
+
+.min-clean-embed .markdown-preview-view .markdown-embed-content {
+  overflow: visible;
+}
+
+.min-clean-embed .markdown-embed-title {
+  display: none;
+}
+
+.min-clean-embed .internal-embed .markdown-embed {
+  border: none;
+  background-color: transparent;
+}
+
+.min-clean-embed .internal-embed .markdown-embed .markdown-preview-view,
+.min-clean-embed
+  .internal-embed
+  .markdown-embed
+  .markdown-preview-view
+  .markdown-preview-sizer,
+.min-clean-embed
+  .internal-embed
+  .markdown-embed
+  .markdown-preview-view.is-readable-line-width
+  .markdown-preview-sizer {
+  padding: 0;
+  margin: 0;
+}
+
+.min-clean-embed .internal-embed .markdown-embed-link {
+  top: -5px;
+  right: -5px;
+  line-height: inherit;
+}
+
+.min-clean-embed .markdown-preview-view .markdown-embed-content,
+.min-clean-embed
+  .markdown-preview-view
+  .markdown-embed-content
+  > .markdown-preview-view {
+  max-height: none;
+}
+
+.no-fx-icons .nav-folder-title .collapse-icon {
+  display: flex;
+  margin-left: 6px;
+}
+
+.nav-folder-title .collapse-icon {
+  display: flex;
+  margin-right: 5px;
+  margin-left: 5px;
+}
+
+.show-fx-folder-icons .nav-folder-title .collapse-icon {
+  display: none;
+}
+
+.show-fx-folder-icons
+  .nav-folder.mod-root
+  > .nav-folder-title
+  .nav-folder-title-content::before {
+  background-color: currentColor;
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M20 18H4V8h16m0-2h-8l-2-2H4c-1.11 0-2 .89-2 2v12a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2z"></path></svg>');
+  font-size: calc(var(--large-font-size) + 5px);
+  display: inline-block;
+  vertical-align: -0.15em;
+  margin-right: 8px;
+  margin-left: -1px;
+}
+
+.show-fx-folder-icons
+  .nav-folder.is-collapsed
+  .nav-folder-title
+  .nav-folder-title-content::before {
+  background-color: currentColor;
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M20 18H4V8h16m0-2h-8l-2-2H4c-1.11 0-2 .89-2 2v12a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2z"></path></svg>');
+  font-size: calc(var(--large-font-size) + 5px);
+  display: inline-block;
+  vertical-align: -0.125em;
+  margin-right: 8px;
+  margin-left: -1px;
+}
+
+.show-fx-folder-icons
+  .nav-folder
+  .nav-folder-title
+  .nav-folder-title-content::before {
+  content: "☐";
+  font-family: sans-serif;
+  align-items: center;
+  justify-content: center;
+  background-color: currentColor;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M6.1 10L4 18V8h17a2 2 0 0 0-2-2h-7l-2-2H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h15c.9 0 1.7-.6 1.9-1.5l2.3-8.5H6.1M19 18H6l1.6-6h13L19 18z"></path></svg>');
+  font-size: calc(var(--large-font-size) + 5px);
+  display: inline-block;
+  vertical-align: -0.125em;
+  margin-right: 8px;
+  margin-left: -1px;
+}
+
+.no-fx-icons .nav-file-icon:before,
+.no-fx-icons .nav-file-title-content:before,
+.no-fx-icons .nav-folder-children .nav-file-title-content:first-child::before,
+.no-fx-icons .nav-folder .nav-folder-title .nav-folder-title-content::before,
+.no-fx-icons
+  .nav-folder.is-collapsed
+  .nav-folder-title
+  .nav-folder-title-content::before,
+.no-fx-icons
+  .nav-folder.mod-root
+  > .nav-folder-title
+  .nav-folder-title-content::before {
+  content: "";
+  margin-right: unset;
+}
+
+.no-fx-reverse
+  .workspace-leaf-content[data-type="file-explorer"]
+  .nav-file-title {
+  margin-right: unset;
+  flex-direction: unset;
+}
+
+.no-fx-reverse .nav-file-title-content:before {
+  content: "";
+}
+
+/* WYSIWYG HEADERS  */
+
+:root {
+  --h1: 1rem;
+  --h2: 0.95rem;
+  --h3: 0.9rem;
+  --h4: 0.85rem;
+  --h5: 0.8rem;
+  --h6: 0.75rem;
+}
+
+body:not(.is-mobile).wys-headings
+  div:not(.CodeMirror-activeline)
+  > pre
+  .cm-formatting.cm-formatting-header.cm-formatting-header-1.cm-header.cm-header-1,
+body:not(.is-mobile).wys-headings
+  div:not(.CodeMirror-activeline)
+  > pre
+  .cm-formatting.cm-formatting-header.cm-formatting-header-2.cm-header.cm-header-2,
+body:not(.is-mobile).wys-headings
+  div:not(.CodeMirror-activeline)
+  > pre
+  .cm-formatting.cm-formatting-header.cm-formatting-header-3.cm-header.cm-header-3,
+body:not(.is-mobile).wys-headings
+  div:not(.CodeMirror-activeline)
+  > pre
+  .cm-formatting.cm-formatting-header.cm-formatting-header-4.cm-header.cm-header-4,
+body:not(.is-mobile).wys-headings
+  div:not(.CodeMirror-activeline)
+  > pre
+  .cm-formatting.cm-formatting-header.cm-formatting-header-5.cm-header.cm-header-5,
+body:not(.is-mobile).wys-headings
+  div:not(.CodeMirror-activeline)
+  > pre
+  .cm-formatting.cm-formatting-header.cm-formatting-header-6.cm-header.cm-header-6 {
+  font-size: 0px !important;
+}
+
+.wys-headings
+  div:not(.CodeMirror-activeline)
+  > .cm-formatting.cm-formatting-header.cm-formatting-header-1.cm-header.cm-header-1,
+.wys-headings
+  div:not(.CodeMirror-activeline)
+  > .cm-formatting.cm-formatting-header.cm-formatting-header-2.cm-header.cm-header-2,
+.wys-headings
+  div:not(.CodeMirror-activeline)
+  > .cm-formatting.cm-formatting-header.cm-formatting-header-3.cm-header.cm-header-3,
+.wys-headings
+  div:not(.CodeMirror-activeline)
+  > .cm-formatting.cm-formatting-header.cm-formatting-header-4.cm-header.cm-header-4,
+.wys-headings
+  div:not(.CodeMirror-activeline)
+  > .cm-formatting.cm-formatting-header.cm-formatting-header-5.cm-header.cm-header-5,
+.wys-headings
+  div:not(.CodeMirror-activeline)
+  > .cm-formatting.cm-formatting-header.cm-formatting-header-6.cm-header.cm-header-6 {
+  font-size: 0.5px !important;
+  color: transparent !important;
+  margin: 0;
+  padding: 0;
+}
+
+.wys-headings div:not(.CodeMirror-activeline) > .HyperMD-header-1:before {
+  content: "H1";
+  display: inline-block;
+  color: var(--text-muted);
+  font-size: var(--h1);
+  font-family: var(--f-header-1-ed);
+  margin-right: calc(var(--h1) / 2);
+  border: 1px solid none;
+  border-radius: 4px;
+  padding: calc(var(--h1) / 10);
+}
+
+.wys-headings div:not(.CodeMirror-activeline) > .HyperMD-header-2:before {
+  content: "H2";
+  color: var(--text-muted);
+  font-size: var(--h2);
+  font-family: var(--f-header-2-ed);
+  margin-right: calc(var(--h1) / 2);
+  border: 1px solid none;
+  border-radius: 4px;
+  padding: calc(var(--h2) / 10);
+}
+
+.wys-headings div:not(.CodeMirror-activeline) > .HyperMD-header-3:before {
+  content: "H3";
+  color: var(--text-muted);
+  font-size: var(--h3);
+  font-family: var(--f-header-3-ed);
+  margin-right: calc(var(--h1) / 2);
+  border: 1px solid none;
+  border-radius: 4px;
+  padding: calc(var(--h3) / 10);
+}
+
+.wys-headings div:not(.CodeMirror-activeline) > .HyperMD-header-4:before {
+  content: "H4";
+  color: var(--text-muted);
+  font-size: var(--h4);
+  font-family: var(--f-header-4-ed);
+  margin-right: calc(var(--h1) / 2);
+  border: 1px solid none;
+  border-radius: 4px;
+  padding: calc(var(--h4) / 10);
+}
+
+.wys-headings div:not(.CodeMirror-activeline) > .HyperMD-header-5:before {
+  content: "H5";
+  color: var(--text-muted);
+  font-size: var(--h5);
+  font-family: var(--f-header-5-ed);
+  margin-right: calc(var(--h1) / 2);
+  border: 1px solid none;
+  border-radius: 4px;
+  padding: calc(var(--h5) / 10);
+}
+
+.wys-headings div:not(.CodeMirror-activeline) > .HyperMD-header-6:before {
+  content: "H6";
+  color: var(--text-muted);
+  font-size: var(--h6);
+  font-family: var(--f-header-6-ed);
+  margin-right: calc(var(--h1) / 2);
+  border: 1px solid none;
+  border-radius: 4px;
+  padding: calc(var(--h6) / 10);
+}
+
+/* WYSIWYG ENHANCED credit to @deathau https://github.com/deathau/obsidian-snippets/blob/main/clutter-free-formatting.css*/
+
+/* Remove markdown clutter */
+.wys-enhanced
+  div:not(.CodeMirror-activeline)
+  > .CodeMirror-line
+  span.cm-formatting,
+.wys-enhanced
+  div:not(.CodeMirror-activeline)
+  > .CodeMirror-line
+  span.cm-formatting-link,
+.wys-enhanced
+  div:not(.CodeMirror-activeline)
+  > .CodeMirror-line
+  span.cm-formatting-link:not(.cm-link),
+.wys-enhanced
+  div:not(.CodeMirror-activeline)
+  > .CodeMirror-line
+  span.cm-hmd-barelink,
+.wys-enhanced div:not(.CodeMirror-activeline) > .CodeMirror-line span.cm-tag {
+  display: none !important;
+}
+
+.wys-enhanced
+  div:not(.CodeMirror-activeline)
+  > .CodeMirror-line
+  span.cm-formatting.cm-formatting-code-block.cm-hmd-codeblock {
+  display: inline !important;
+}
+
+.wys-enhanced
+  div:not(.CodeMirror-activeline)
+  > .CodeMirror-line
+  span.cm-formatting-task {
+  display: inline !important;
+}
+
+/* except numbered list */
+.wys-enhanced
+  div:not(.CodeMirror-activeline)
+  > .CodeMirror-line
+  span.cm-formatting-list {
+  display: inline !important;
+}
+
+/* and task checkboxes */
+.wys-enhanced span.cm-formatting-task {
+  display: inline !important;
+}
+
+/* highlight (==) not visible anymore if not active line */
+.wys-enhanced
+  div:not(.CodeMirror-activeline)
+  > .CodeMirror-line
+  .cm-formatting-highlight.cm-highlight {
+  font-size: 0;
+}
+
+/* Unordered lists: turn into bullets as you type, as per Typora */
+.wys-enhanced span.cm-formatting-list-ul {
+  color: transparent !important;
+  position: relative;
+}
+
+.wys-enhanced .cm-formatting-list-ul:before {
+  line-height: 0;
+  position: absolute;
+  top: 51%;
+  left: 3px;
+  display: block;
+  transform: translate(-56%, -50%);
+  width: 6px;
+  height: 6px;
+  content: url('data:image/svg+xml; utf8, <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" style="fill:rgba(0, 0, 0);"><path d="M12,2C6.486,2,2,6.486,2,12s4.486,10,10,10s10-4.486,10-10S17.514,2,12,2z"></path></svg>');
+}
+
+.theme-dark.wys-enhanced .cm-formatting-list-ul:before {
+  content: url('data:image/svg+xml; utf8, <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" style="fill:rgba(204,204,204);"><path d="M12,2C6.486,2,2,6.486,2,12s4.486,10,10,10s10-4.486,10-10S17.514,2,12,2z"></path></svg>');
+}
+
+/* Blockquote: in edit mode with left border rendered instead of > */
+.wys-enhanced
+  div:not(.CodeMirror-activeline)
+  > .CodeMirror-line
+  span.cm-formatting.cm-formatting-quote,
+.wys-enhanced
+  div:not(.CodeMirror-activeline)
+  > .CodeMirror-line
+  span.cm-hmd-indent-in-quote {
+  display: inline !important;
+  color: transparent !important;
+}
+
+.wys-enhanced div:not(.CodeMirror-activeline) > .HyperMD-quote:before {
+  font-size: 2.5em;
+  margin-right: -0.25em;
+  margin-left: 0.35em;
+  line-height: 0.1em;
+  vertical-align: -0.3em;
+  display: inline;
+  position: relative;
+}
+
+.wys-enhanced .cm-s-obsidian span.cm-quote {
+  color: hsl(var(--blockquote-border));
+  display: inline;
+}
+
+.wys-enhanced div:not(.CodeMirror-activeline) > .HyperMD-quote {
+  line-height: 1.75em;
+  color: hsl(var(--blockquote-border));
+  font-family: var(--default-font);
+  border: none;
+  border-left: 0.3rem solid hsl(var(--blockquote-border));
+  background-color: var(--blockquote-bg);
+  border-radius: 0px;
+  padding-left: 2rem;
+  display: inline-block;
+  width: 100%;
+}
+
+/* Tag pills in edit mode */
+.wys-enhanced
+  div:not(.CodeMirror-activeline)
+  > .CodeMirror-line
+  span.cm-hashtag-end:before {
+  content: "#";
+  font-size: 0.875em;
+}
+
+.wys-enhanced
+  div:not(.CodeMirror-activeline)
+  > .CodeMirror-line
+  span.cm-hashtag-end {
+  background-color: var(--tag-base);
+  border: 1px solid var(--interactive-accent);
+  color: var(--text-normal);
+  font-size: 0.875em;
+  font-weight: 500;
+  padding-left: 6px;
+  padding-right: 6px;
+  text-align: center;
+  text-decoration: none !important;
+  display: inline-block;
+  cursor: pointer;
+  border-radius: 8px;
+  transition: 0.1s ease-in-out;
+}
+
+.wys-enhanced
+  div:not(.CodeMirror-activeline)
+  > .CodeMirror-line
+  span.cm-hashtag-end:hover {
+  color: var(--interactive-accent);
+  text-decoration: none !important;
+  transition: 0.1s ease-in-out;
+}
+
+/*RAINBOW HEADERS*/
+
+.rainbow-headers .cm-s-obsidian .cm-header.cm-header-1,
+.rainbow-headers .markdown-preview-section h1 {
+  color: var(--text-title-h1);
+}
+
+.rainbow-headers .cm-s-obsidian .cm-header.cm-header-2,
+.rainbow-headers .markdown-preview-section h2 {
+  color: var(--text-title-h2);
+}
+
+.rainbow-headers .cm-s-obsidian .cm-header.cm-header-3,
+.rainbow-headers .markdown-preview-section h3 {
+  color: var(--text-title-h3);
+}
+
+.rainbow-headers .cm-s-obsidian .cm-header.cm-header-4,
+.rainbow-headers .markdown-preview-section h4 {
+  color: var(--text-title-h4);
+}
+
+.rainbow-headers .cm-s-obsidian .cm-header.cm-header-5,
+.rainbow-headers .markdown-preview-section h5 {
+  color: var(--text-title-h5);
+}
+
+.rainbow-headers .cm-s-obsidian .cm-header.cm-header-6,
+.rainbow-headers .markdown-preview-section h6 {
+  color: var(--text-title-h6);
+}
+
+:root {
+  --all-sides-bg: ;
+  --as-size: 50px;
+  --as-filter: blur(0px) brightness(90%) saturate(0%);
+  --as-repeat: repeat;
+
+  --graph-input-bg: ;
+  --gp-size: 50px;
+  --gp-filter: blur(0px) brightness(90%) saturate(0%);
+  --gp-repeat: repeat;
+
+  --fx-input-bg: ;
+  --fx-size: 50px;
+  --fx-filter: blur(0px) brightness(90%) saturate(0%);
+  --fx-repeat: repeat;
+
+  --backlink-input-bg: ;
+  --bp-size: 50px;
+  --bp-filter: blur(0px) brightness(90%) saturate(0%);
+  --bp-repeat: repeat;
+
+  --tag-input-bg: ;
+  --tp-size: 50px;
+  --tp-filter: blur(0px) brightness(90%) saturate(0%);
+  --tp-repeat: repeat;
+
+  --calendar-input-bg: ;
+  --cp-size: 50px;
+  --cp-filter: blur(0px) brightness(90%) saturate(0%);
+  --cp-repeat: repeat;
+}
+
+.all-sides .workspace-tabs .workspace-leaf-content .view-content {
+  z-index: 0;
+}
+
+.all-sides
+  .workspace-split.mod-left-split
+  .workspace-tabs
+  .workspace-leaf-content::after,
+.all-sides
+  .workspace-split.mod-right-split
+  .workspace-tabs
+  .workspace-leaf-content::after {
+  z-index: -1;
+  content: "";
+  position: absolute;
+  background-image: var(--all-sides-bg);
+  background-repeat: var(--as-repeat);
+  background-size: var(--as-size);
+  filter: var(--as-filter);
+  opacity: 0.1;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+}
+
+/* CUSTOM BACKGROUNDS */
+
+.spec-sides .workspace-tabs .workspace-leaf-content .view-content {
+  z-index: 0;
+}
+
+.spec-sides
+  .workspace-split.mod-left-split
+  .workspace-tabs
+  .workspace-leaf-content[data-type="graph"]::after,
+.spec-sides
+  .workspace-split.mod-right-split
+  .workspace-tabs
+  .workspace-leaf-content[data-type="graph"]::after {
+  z-index: -1;
+  content: "";
+  position: absolute;
+  background-image: var(--graph-input-bg);
+  background-repeat: repeat;
+  background-size: 50px;
+  filter: blur(0px) brightness(90%) saturate(0%);
+  opacity: 0.1;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+}
+
+.spec-sides
+  .theme-dark
+  .workspace-split.mod-left-split
+  .workspace-tabs
+  .workspace-leaf-content[data-type="graph"]::after,
+.spec-sides
+  .theme-dark
+  .workspace-split.mod-right-split
+  .workspace-tabs
+  .workspace-leaf-content[data-type="graph"]::after {
+  opacity: 0.15;
+}
+
+.spec-sides .workspace-tabs .workspace-leaf-content .view-content {
+  z-index: 0;
+}
+
+.spec-sides
+  .workspace-split.mod-left-split
+  .workspace-tabs
+  .workspace-leaf-content[data-type="file-explorer"]::after,
+.spec-sides
+  .workspace-split.mod-right-split
+  .workspace-tabs
+  .workspace-leaf-content[data-type="file-explorer"]::after {
+  z-index: -1;
+  content: "";
+  position: absolute;
+  background-image: var(--fx-input-bg);
+  background-repeat: repeat;
+  background-size: 50px;
+  filter: blur(0px) brightness(90%) saturate(0%);
+  opacity: 0.1;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+}
+
+.spec-sides .workspace-tabs .workspace-leaf-content .view-content {
+  z-index: 0;
+}
+
+.spec-sides
+  .workspace-split.mod-left-split
+  .workspace-tabs
+  .workspace-leaf-content[data-type="backlink"]::after,
+.spec-sides
+  .workspace-split.mod-right-split
+  .workspace-tabs
+  .workspace-leaf-content[data-type="backlink"]::after {
+  z-index: -1;
+  content: "";
+  position: absolute;
+  background-image: var(--backlink-input-bg);
+  background-repeat: repeat;
+  background-size: 50px;
+  filter: blur(0px) brightness(90%) saturate(0%);
+  opacity: 0.1;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+}
+
+.spec-sides .workspace-tabs .workspace-leaf-content .view-content {
+  z-index: 0;
+}
+
+.spec-sides
+  .workspace-split.mod-left-split
+  .workspace-tabs
+  .workspace-leaf-content[data-type="tag"]::after,
+.spec-sides
+  .workspace-split.mod-right-split
+  .workspace-tabs
+  .workspace-leaf-content[data-type="tag"]::after {
+  z-index: -1;
+  content: "";
+  position: absolute;
+  background-image: var(--tag-input-bg);
+  background-repeat: repeat;
+  background-size: 50px;
+  filter: blur(0px) brightness(90%) saturate(0%);
+  opacity: 0.1;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+}
+
+.spec-sides .workspace-tabs .workspace-leaf-content .view-content {
+  z-index: 0;
+}
+
+.spec-sides
+  .workspace-split.mod-left-split
+  .workspace-tabs
+  .workspace-leaf-content[data-type="calendar"]::after,
+.spec-sides
+  .workspace-split.mod-right-split
+  .workspace-tabs
+  .workspace-leaf-content[data-type="calendar"]::after {
+  z-index: -1;
+  content: "";
+  position: absolute;
+  background-image: var(--calendar-input-bg);
+  background-repeat: repeat;
+  background-size: 50px;
+  filter: blur(0px) brightness(90%) saturate(0%);
+  opacity: 0.1;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+}
+
+/*MACOS-LIKE TRANSLUCENY*/
+
+.is-translucent:not(.macOS-translucent).theme-light {
+  --opacity-translucency: 0.6;
+}
+
+.is-translucent:not(.macOS-translucent).theme-dark {
+  --opacity-translucency: 0.7;
+}
+
+.is-translucent .workspace-leaf-resize-handle {
+  opacity: var(--opacity-translucency);
+  background-color: transparent;
+}
+/*
+.macOS-translucent .nav-action-button.is-active,
+.macOS-translucent .workspace-tab-header.is-active,
+.macOS-translucent .graph-controls.is-close{
+--background-primary: var(--background-zero);
+}*/
+
+.macOS-translucent.is-translucent .titlebar {
+  background-color: var(--background-translucent);
+}
+
+.macOS-translucent.is-translucent .workspace {
+  background-color: var(--background-translucent) !important;
+}
+
+.macOS-translucent.is-translucent .workspace-split .workspace-tabs {
+  background: var(--background-primary) !important;
+}
+
+.macOS-translucent.is-translucent .workspace-split .workspace-tabs {
+  background-color: transparent !important;
+  box-shadow: inset -10px 0 4px -10px rgba(0, 0, 0, 0.04);
+}
+
+.focus-mode.macOS-translucent.is-translucent .workspace {
+  background-color: var(--background-primary) !important;
+}
+
+.macOS-translucent.is-translucent .workspace-ribbon.mod-right,
+.macOS-translucent.is-translucent .workspace-ribbon.mod-left {
+  background: transparent;
+}
+
+.macOS-translucent.is-translucent .mod-horizontal .workspace-leaf {
+  border-bottom: 0px;
+  background-color: transparent;
+  box-shadow: none !important;
+}
+
+.macOS-translucent.is-translucent.theme-light .workspace {
+  --text-muted: hsl(
+    var(--base-h),
+    calc(var(--base-s) - 3%),
+    calc(var(--base-l) - 50%)
+  );
+  --svg-faint: hsl(
+    var(--base-h),
+    calc(var(--base-s) - 3%),
+    calc(var(--base-l) - 38%)
+  );
+}
+
+/*----------------------------------------------------------------
+MOBILE TWEAKS
+----------------------------------------------------------------*/
+
+.is-mobile .modal.mod-community-theme,
+.is-mobile .modal.mod-community-plugin,
+.is-mobile .prompt,
+.is-mobile .modal.mod-settings {
+  width: 100vw;
+  height: 90vh;
+  max-height: calc(100% - 70px);
+  max-width: none;
+}
+
+.is-mobile .modal-bg {
+  transition: none !important;
+  transform: none !important;
+}
+
+.is-mobile .prompt {
+  transition: unset !important;
+  transform: unset !important;
+  animation: unset !important;
+  box-shadow: 0px 3px 15px
+    hsla(var(--base-h), var(--base-s), calc(var(--base-l) - 50%), 0.15) !important;
+  padding: 2px; /* solve focus prompt-input border break */
+}
+
+.is-mobile .workspace {
+  border-radius: 0 !important;
+  transform: none !important;
+  padding: 15px; /* adjust mobile workspace padding */
+}
+
+/* adjust embedded box content padding */
+.is-mobile .markdown-preview-sizer .markdown-embed-content{
+  padding: 15px;
+}
+
+.workspace-drawer-active-tab-container.is-fullscreen {
+  z-index: 4;
+}
+body:not(.no-svg-replace).is-mobile svg.right-triangle {
+  width: 12px;
+  height: 12px;
+}
+
+body:not(.no-svg-replace).is-mobile
+  .frontmatter-collapse-indicator
+  svg.right-triangle {
+  margin-left: 25px;
+  margin-top: -4px;
+}
+
+body:not(.no-svg-replace).is-mobile span[title="Unfold line"]:after,
+body:not(.no-svg-replace).is-mobile .CodeMirror-foldgutter-folded:after {
+  content: "›";
+  font-family: sans-serif;
+  transform: translateY(-2px);
+  transform: rotate(-90deg);
+}
+
+body:not(.no-svg-replace).is-mobile span[title="Fold line"]:after,
+body:not(.no-svg-replace).is-mobile .CodeMirror-foldgutter-open:after {
+  content: "›";
+  font-family: sans-serif;
+  transform: rotate(360deg);
+}
+
+.markdown-source-view.mod-cm6 .cm-scroller,
+.cm-s-obsidian {
+  line-height: var(--editor-line-height);
+}
+
+.is-mobile input.prompt-input,
+.is-mobile input.prompt-input:hover {
+  padding: 16px;
+}
+
+.is-mobile .nav-buttons-container {
+  padding: 8px 0;
+  border: 0;
+  line-height: 1;
+}
+
+.is-mobile .nav-action-button {
+  padding: 8px 8px !important;
+  display: flex;
+}
+
+.is-mobile .tree-item-self:hover {
+  background-color: unset;
+}
+
+.is-mobile .nav-header h6#status {
+  padding-top: 32px;
+}
+
+.is-mobile .workspace-drawer-header-left {
+  justify-content: center;
+}
+
+.is-mobile .workspace-drawer-ribbon .side-dock-ribbon-action {
+  padding: 6px 0;
+}
+
+.is-mobile .side-dock-settings {
+  margin-bottom: -10px;
+  padding: 0;
+}
+
+.is-mobile .workspace-drawer-header-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  align-self: flex-start;
+  margin-top: 6px;
+}
+
+.is-mobile .menu {
+  border-radius: 12px;
+}
+
+.is-mobile .modal.mod-settings .vertical-tab-content-container {
+  border: none;
+}
+
+.is-mobile .modal.mod-settings .vertical-tab-content {
+  border: none;
+}
+
+.is-mobile .modal.mod-community-plugin,
+.is-mobile .modal.mod-settings,
+.is-mobile .modal {
+  border: none;
+  border-color: transparent;
+}
+
+.is-mobile .modal,
+.is-mobile .prompt,
+.is-mobile .suggestion-container {
+  border-top-left-radius: 18px;
+  border-top-right-radius: 18px;
+  max-height: calc(100% - 56px);
+  max-width: calc(100% - 0px);
+}
+
+.modal,
+.prompt,
+.suggestion-container {
+  box-shadow: 0px 5px 30px rgba(5, 6, 5, 0.15);
+}
+
+.is-mobile .modal-setting-back-button {
+  padding: 20px;
+  background-color: unset;
+  box-shadow: none;
+}
+
+.is-mobile .modal.mod-settings .vertical-tab-content {
+  background-color: var(--background-primary);
+  padding: 20px 20px;
+  height: calc(100% - 56px);
+}
+
+.is-mobile .modal.mod-community-plugin,
+.is-mobile .modal.mod-settings {
+  width: 100vw;
+  border-top-left-radius: 18px;
+  border-top-right-radius: 18px;
+}
+
+.is-mobile .suggestion-container .suggestion {
+  padding: 10px;
+}
+
+.is-mobile .workspace-drawer-active-tab-header {
+  cursor: pointer;
+}
+
+.is-mobile .mod-left .workspace-drawer-header,
+.is-mobile .mod-left .workspace-drawer-tab-container {
+  margin-left: 12px;
+  margin-top: 12px;
+}
+
+.is-mobile .workspace-drawer.mod-left,
+.is-mobile .workspace-drawer.mod-right {
+  background-color: var(--background-secondary);
+}
+
+.is-mobile .workspace-drawer-ribbon {
+  background: var(--background-secondary);
+  border-right: 1px solid var(--background-modifier-border);
+  z-index: 3;
+  flex-direction: column;
+  width: 52px;
+}
+
+.is-mobile .workspace-drawer-tab-option-item {
+  margin: 0 10px;
+  padding: 6px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.is-mobile .workspace-drawer-tab-option-item:hover {
+  background-color: var(--background-primary-alt);
+}
+
+.is-mobile .menu-item-icon svg {
+  height: 18px !important;
+  width: 18px !important;
+  vertical-align: -0.125em;
+}
+
+.is-mobile .nav-action-button svg {
+  width: 20px;
+  height: 20px;
+}
+
+.is-mobile .view-action svg,
+.is-mobile .workspace-drawer-header-icon svg,
+.is-mobile .workspace-drawer-ribbon .side-dock-ribbon-action svg {
+  width: 22px;
+  height: 22px;
+}
+
+.is-mobile .community-plugin-search .setting-item-control {
+  justify-content: center;
+}
+
+.is-mobile .setting-item-control {
+  margin-right: 10px;
+}
+
+.is-mobile .setting-item-control {
+  flex: 1 1 auto;
+  text-align: right;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+}
+
+.community-plugin-search .search-input-container {
+  margin-left: 0px;
+}
+
+.community-plugin-search {
+  flex: 3 0 100px;
+  background-color: var(--background-secondary-alt);
+  padding: 28px 0 0 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.community-plugin-search .setting-item-control {
+  padding-top: 5px;
+  padding-right: 8px;
+  width: 100%;
+}
+
+.search-input-container {
+  width: calc(100% - 20px);
+}
+
+.is-mobile .menu-item {
+  padding: 5px 10px;
+  margin: 0 1px;
+}
+
+@media (max-width: 400pt) {
+  .is-mobile .modal.mod-community-plugin,
+  .is-mobile .modal.mod-settings {
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+  }
+  .modal.mod-settings .vertical-tab-content-container .search-input-container {
+    width: 100%;
+    margin: 0 auto;
+    padding: 0;
+  }
+}
+
+@media (min-width: 400pt) {
+  .is-mobile .menu {
+    top: 60px !important;
+    right: 0 !important;
+    bottom: auto;
+    left: auto;
+    margin: 0 auto;
+    width: 345px;
+    padding: 10px 10px 20px;
+    border-radius: 15px;
+    box-shadow: 0 0 100vh 100vh rgb(0 0 0 / 50%);
+  }
+}
+
+@media (min-width: 400pt) {
+  /*phone*/
+  .is-mobile .setting-item:not(.mod-toggle):not(.setting-item-heading) {
+    flex-direction: row;
+    align-items: center;
+  }
+
+  .is-mobile .hotkey-list-container .setting-item-control {
+    margin-top: 10px;
+    align-items: flex-start;
+  }
+
+  .is-mobile .hotkey-list-container .setting-command-hotkeys {
+    flex: none;
+  }
+
+  .is-mobile
+    .setting-item:not(.mod-toggle):not(.setting-item-heading)
+    .setting-item-control {
+    width: auto;
+    margin-top: 0;
+  }
+
+  .is-mobile .setting-item-control select,
+  .is-mobile .setting-item-control input,
+  .is-mobile .setting-item-control button {
+    width: auto;
+  }
+}
+
+/*----------------------------------------------------------------
+PLUGINS!!!
+----------------------------------------------------------------*/
+
+/*----------------------------------------------------------------
+WORKSPACES PLUS
+----------------------------------------------------------------*/
+
+.rename-workspace svg path {
+  display: none;
+}
+
+.delete-workspace svg path {
+  display: none;
+}
+
+.rename-workspace svg,
+.delete-workspace svg {
+  background-color: var(--text-muted);
+}
+
+.rename-workspace,
+.delete-workspace {
+  margin-top: 0.5em !important;
+}
+
+.rename-workspace svg {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="red" d="M20.005 5.995h-1v2h1v8h-1v2h1c1.103 0 2-.897 2-2v-8c0-1.102-.898-2-2-2zm-14 4H15v4H6.005z"/><path fill="red" d="M17.005 17.995V4H20V2h-8v2h3.005v1.995h-11c-1.103 0-2 .897-2 2v8c0 1.103.897 2 2 2h11V20H12v2h8v-2h-2.995v-2.005zm-13-2v-8h11v8h-11z"></path></svg>');
+}
+
+.delete-workspace svg {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="black" d="M37.5 12.5v4.167H16.667v8.333h4.167v54.167a8.333 8.333 0 0 0 8.333 8.333h41.667a8.333 8.333 0 0 0 8.333 -8.333V25h4.167V16.667h-20.833V12.5H37.5M29.167 25h41.667v54.167H29.167V25m8.333 8.333v37.5h8.333V33.333H37.5m16.667 0v37.5h8.333V33.333h-8.333z"></path></svg>');
+}
+
+.status-bar-item.plugin-workspaces-plus.mod-clickable {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+/*----------------------------------------------------------------
+QUICKADD
+----------------------------------------------------------------*/
+
+.alignIconInDivInMiddle.svelte-a47k80[aria-label="Add command for new"] svg,
+.alignIconInDivInMiddle.svelte-a47k80[aria-label="Configure new"] svg,
+.alignIconInDivInMiddle.svelte-a47k80[aria-label="Delete new"] svg,
+.alignIconInDivInMiddle.svelte-a47k80[aria-label="Drag-handle"] svg {
+  background-color: currentColor;
+  height: 19px;
+  width: 19px;
+}
+
+.alignIconInDivInMiddle.svelte-a47k80[aria-label="Add command for new"] svg {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M54.167 29.167h-8.333v16.667H29.167v8.333h16.667v16.667h8.333v-16.667h16.667v-8.333h-16.667z M50 8.333C27.025 8.333 8.333 27.025 8.333 50s18.692 41.667 41.667 41.667s41.667 -18.692 41.667 -41.667S72.975 8.333 50 8.333zm0 75c-18.379 0 -33.333 -14.954 -33.333 -33.333s14.954 -33.333 33.333 -33.333s33.333 14.954 33.333 33.333s-14.954 33.333 -33.333 33.333z"></path></svg>');
+}
+
+.alignIconInDivInMiddle.svelte-a47k80[aria-label="Configure new"] svg {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="red" d="M50 66.667c9.192 0 16.667 -7.475 16.667 -16.667s-7.475 -16.667 -16.667 -16.667s-16.667 7.475 -16.667 16.667s7.475 16.667 16.667 16.667zm0 -25c4.517 0 8.333 3.817 8.333 8.333s-3.817 8.333 -8.333 8.333s-8.333 -3.817 -8.333 -8.333s3.817 -8.333 8.333 -8.333z"/><path fill="red" d="M11.854 67.233l4.167 7.208c2.213 3.821 7.538 5.254 11.375 3.042l2.204 -1.275A33.75 33.75 0 0 0 37.5 80.842V83.333c0 4.596 3.738 8.333 8.333 8.333h8.333c4.596 0 8.333 -3.738 8.333 -8.333v-2.492a33.883 33.883 0 0 0 7.9 -4.629l2.204 1.275c3.846 2.208 9.158 0.783 11.379 -3.046l4.163 -7.204a8.338 8.338 0 0 0 -3.046 -11.383l-2.104 -1.217a32.158 32.158 0 0 0 0 -9.267l2.104 -1.217a8.342 8.342 0 0 0 3.046 -11.383l-4.163 -7.204c-2.213 -3.833 -7.533 -5.271 -11.379 -3.05l-2.204 1.275A33.75 33.75 0 0 0 62.5 19.158V16.667c0 -4.596 -3.738 -8.333 -8.333 -8.333h-8.333c-4.596 0 -8.333 3.738 -8.333 8.333v2.492a33.883 33.883 0 0 0 -7.9 4.629l-2.204 -1.275c-3.85 -2.213 -9.167 -0.779 -11.379 3.05l-4.163 7.204a8.338 8.338 0 0 0 3.046 11.383l2.104 1.217a32.013 32.013 0 0 0 0 9.262l-2.104 1.217a8.346 8.346 0 0 0 -3.046 11.388zm13.858 -11.492A23.763 23.763 0 0 1 25 50c0 -1.925 0.242 -3.858 0.708 -5.742a4.163 4.163 0 0 0 -1.958 -4.617l-4.679 -2.708l4.158 -7.204l4.771 2.758a4.154 4.154 0 0 0 4.95 -0.592a25.296 25.296 0 0 1 9.933 -5.829A4.167 4.167 0 0 0 45.833 22.083V16.667h8.333v5.417a4.167 4.167 0 0 0 2.95 3.983a25.346 25.346 0 0 1 9.933 5.829a4.163 4.163 0 0 0 4.95 0.592l4.767 -2.754l4.167 7.204l-4.683 2.704a4.167 4.167 0 0 0 -1.958 4.617c0.467 1.883 0.708 3.817 0.708 5.742c0 1.921 -0.242 3.854 -0.713 5.742a4.167 4.167 0 0 0 1.963 4.617l4.679 2.704l-4.158 7.204l-4.771 -2.754a4.15 4.15 0 0 0 -4.95 0.592a25.296 25.296 0 0 1 -9.933 5.829A4.167 4.167 0 0 0 54.167 77.917l0.008 5.417H45.833v-5.417a4.167 4.167 0 0 0 -2.95 -3.983a25.346 25.346 0 0 1 -9.933 -5.829a4.133 4.133 0 0 0 -4.95 -0.588l-4.767 2.758l-4.167 -7.204l4.683 -2.713a4.167 4.167 0 0 0 1.963 -4.617z"></path></svg>');
+}
+
+.alignIconInDivInMiddle.svelte-a47k80[aria-label="Delete new"] svg {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="black" d="M37.5 12.5v4.167H16.667v8.333h4.167v54.167a8.333 8.333 0 0 0 8.333 8.333h41.667a8.333 8.333 0 0 0 8.333 -8.333V25h4.167V16.667h-20.833V12.5H37.5M29.167 25h41.667v54.167H29.167V25m8.333 8.333v37.5h8.333V33.333H37.5m16.667 0v37.5h8.333V33.333h-8.333z"></path></svg>');
+}
+
+.alignIconInDivInMiddle.svelte-a47k80[aria-label="Drag-handle"] svg {
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="black" d="M16.667 25h66.667v8.333H16.667zm0 20.833h66.667v8.333H16.667zm0 20.833h66.667v8.333H16.667z"></path></svg>');
+}
+
+/*----------------------------------------------------------------
+CHECKLIST
+----------------------------------------------------------------*/
+
+header.svelte-yzsyxo {
+  border: 0.025em solid var(--background-modifier-border) !important;
+  background-color: var(--background-primary-alt) !important;
+  padding: 7.5px 8px 7.5px 8px !important;
+  margin-bottom: 12px !important;
+  border-radius: 5px !important;
+  font-size: var(--todoList-headerFontSize) !important;
+}
+
+/*----------------------------------------------------------------
+LONGFORM
+----------------------------------------------------------------*/
+
+input#new-scene.svelte-1lq63fp,
+input#new-draft.svelte-1wkli4h {
+  padding: 5px 14px;
+}
+
+.right-arrow.svelte-nr1d94.svelte-nr1d94::after {
+  width: 1em !important;
+  height: 1em !important;
+  background-color: currentColor;
+  clip-path: none !important;
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="black" d="M10.707 17.707L16.414 12l-5.707-5.707l-1.414 1.414L13.586 12l-4.293 4.293z"></path></svg>');
+}
+
+/*----------------------------------------------------------------
+ELECTRON WINDOW TWEAKER
+----------------------------------------------------------------*/
+
+.ewt-statusbar-menu .menu-item-title {
+  margin-right: 10px !important;
+}
+
+/*----------------------------------------------------------------
+FILE TREE ALTERNATIVE PLUGIN
+----------------------------------------------------------------*/
+
+div.workspace-leaf-content[data-type="file-tree-view"] > div.view-content {
+  width: 100%;
+}
+
+div.treeview,
+.oz-nav-file-title,
+.oz-file-tree-header {
+  font-size: var(--small-font-size);
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.oz-nav-action-button {
+  color: var(--text-muted) !important;
+}
+
+.oz-nav-action-button:hover {
+  color: hsl(var(--accent-hsl)) !important;
+}
+
+.oz-folder-toggle {
+  vertical-align: -0.15em !important;
+}
+
+svg.oz-folder-toggle path {
+  fill: hsl(
+    var(--l-accent-h),
+    var(--l-accent-s),
+    calc(var(--l-accent-l) - 10%)
+  ) !important;
+}
+
+.theme-dark svg.oz-folder-toggle path {
+  fill: hsl(
+    var(--d-accent-h),
+    var(--d-accent-s),
+    calc(var(--d-accent-l) - 12%)
+  ) !important;
+}
+
+div.oz-nav-file {
+  padding: 0px 0 0 0px;
+}
+
+.oz-folder-element {
+  line-height: 1.2em;
+  padding: 1px 0px 1px 0px;
+}
+
+div.oz-nav-file,
+.oz-nav-file-title,
+.oz-folder-element,
+.oz-folder-element span {
+  transition: 0.3s ease-in-out;
+}
+
+.oz-folder-element:hover span {
+  transition: 0.3s ease-in-out;
+}
+
+div.nav-file-title.oz-nav-file-title:hover span,
+.drag-entered,
+.oz-folder-element:hover {
+  cursor: pointer;
+}
+
+.search-input-container.oz-input-container {
+  width: calc(100% - 0px) !important;
+}
+
+.workspace-tabs
+  .workspace-leaf
+  .workspace-leaf-content[data-type="file-tree-view"]
+  .view-content {
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+.oz-nav-file-title {
+  flex-direction: row-reverse;
+}
+
+.oz-nav-action-button .fa-lg {
+  font-size: 1.15em;
+}
+
+.oz-file-tree-header {
+  margin-top: 12px !important;
+  color: var(--text-muted) !important;
+}
+
+/*----------------------------------------------------------------
+ZOOM PLUGIN
+----------------------------------------------------------------*/
+
+body .zoom-plugin-header {
+  border-bottom: 1px solid var(--background-modifier-border);
+  padding: 20px;
+  padding-top: 10px;
+  padding-bottom: 5px;
+  font-size: 15px;
+}
+
+body .zoom-plugin-title {
+  text-decoration: none;
+  z-index: 10;
+}
+
+/*---------------------------------------------------------------- 
+OBSIDIAN-CALENDAR-PLUGIN 
+----------------------------------------------------------------*/
+
+#calendar-container {
+  padding: 5px 15px;
+  font-size: var(--small-font-size);
+  --color-background-day-empty: var(--background-secondary-alt);
+  /*--color-background-day-active: var(--interactive-accent);*/
+  --color-background-day-active: var(--color-background-day); /* remove hightlight background of the active day in calandar */
+  --color-background-day-hover: var(--background-primary-alt);
+  --color-dot: var(--background-modifier-accent) !important;
+  --color-text-title: var(--text-normal);
+  --color-text-heading: var(--text-muted);
+  --color-text-day: var(--text-normal);
+  --color-text-week-num: var(--text-normal);
+  --color-text-today: var(--interactive-accent);
+  --color-arrow: var(--text-faint);
+  --color-arrow-hover: var(--interactive-accent-hover);
+  --color-button: var(--interactive-accent);
+}
+
+#calendar-container .active,
+#calendar-container .active.today {
+  font-weight: 500;
+  box-shadow: 0 0 0 0.1px rgba(0, 0, 0, 0.1),
+    0 0 0 2px hsla(var(--accent-hsl), 0.75);
+}
+
+#calendar-container .active.day:hover {
+  box-shadow: 0 0 0 0.1px rgba(0, 0, 0, 0.1),
+    0 0 0 2px hsla(var(--accent-hsl), 0.75);
+}
+
+#calendar-container {
+  font-size: 0.8em;
+}
+
+#calendar-container th {
+  padding: 2px;
+}
+
+#calendar-container .day,
+#calendar-container .week-num {
+  padding: 2px;
+}
+
+#calendar-container .week-num:hover,
+#calendar-container .day:hover {
+  background: var(--background-primary-alt);
+}
+
+.workspace-leaf-content[data-type="calendar"] .view-content {
+  padding: 5px 0 0 0;
+}
+
+#calendar-container thead {
+  border-top: 2px solid var(--background-modifier-border);
+}
+
+#calendar-container tr th {
+  font-size: calc(var(--small-font-size) - 5px);
+  font-weight: 500;
+}
+
+#calendar-container tr td {
+  cursor: pointer;
+  transition: 100ms;
+  border: none;
+  padding: 0;
+  width: calc(100% / 7);
+  padding: 5px 0 5px;
+  transition: none;
+}
+
+#calendar-container .table {
+  border-collapse: separate;
+  table-layout: fixed;
+}
+
+#calendar-container h3 {
+  font-weight: 400;
+  font-size: 16px;
+}
+
+#calendar-container svg.dot,
+#calendar-container .active svg.dot {
+  fill: var(--text-accent);
+  stroke: var(--background-modifier-accent);
+  stroke-width: 1;
+}
+
+.mod-root #calendar-container {
+  width: var(--line-width);
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0;
+}
+
+#calendar-container .arrow {
+  color: var(--text-faint);
+}
+
+#calendar-container .year {
+  color: var(--interactive-accent) !important;
+}
+
+#calendar-container .week-num.active,
+#calendar-container .day.active {
+  transition: 100ms;
+  color: var(--text-normal);
+  background-color: var(--color-background-day-active);
+}
+
+#calendar-container .arrow:hover > svg {
+  color: var(--color-arrow-hover);
+}
+
+#calendar-container .button:hover {
+  color: var(--color-background-day-empty);
+}
+
+#calendar-container .reset-button:hover {
+  color: var(--color-arrow-hover);
+}
+
+/*----------------------------------------------------------------
+STOPWATCH PLUGIN
+----------------------------------------------------------------*/
+
+.workspace-leaf-content[data-type="online.tokuhirom.obsidian-stopwatch-plugin"]
+  .view-content {
+  padding: 25px 0 0 25px;
+}
+
+/*----------------------------------------------------------------
+DAILY STATS PLUGIN
+----------------------------------------------------------------*/
+
+text.react-calendar-heatmap-small-text.react-calendar-heatmap-weekday-label,
+text.react-calendar-heatmap-month-label {
+  font-size: 8px !important;
+  text-transform: uppercase;
+  fill: var(--text-muted) !important;
+}
+
+.workspace-leaf-content[data-type="stats-tracker"] .view-content {
+  padding: 25px 0 0 35px;
+}
+
+.workspace-leaf-content[data-type="stats-tracker"] .view-content rect:hover {
+  cursor: pointer;
+  stroke: var(--interactive-accent) !important;
+}
+
+.menu-item-icon:hover rect {
+  stroke-width: 2;
+  stroke: var(--text-normal) !important;
+}
+
+.color-empty {
+  fill: var(--background-tertiary) !important;
+}
+
+.color-filled {
+  fill: var(--text-accent) !important;
+}
+
+#color-elem {
+  color: var(--interactive-accent) !important;
+}
+
+/*----------------------------------------------------------------
+DUAL PLUGIN 
+----------------------------------------------------------------*/
+
+.nav-header h6 {
+  padding-top: 10px;
+  padding-bottom: 5px;
+  border-bottom: 2px solid var(--background-modifier-border);
+}
+
+.nav-header {
+  padding: 5px 20px 5px 20px !important;
+}
+
+#conversationDiv {
+  background-color: transparent !important;
+}
+
+#conversationDiv.nav-header {
+  padding-left: 20px !important;
+  padding-right: 20px !important;
+  padding-bottom: 15px !important;
+}
+
+.nav-header {
+  max-width: 100% !important;
+}
+
+.nav-header#conversationDiv p {
+  color: var(--text-muted);
+  border: none;
+}
+
+.nav-header#conversationDiv > p {
+  font-size: 0.925em !important;
+  color: var(--text-muted);
+  border-radius: 5px;
+  line-height: 1.75 !important;
+  padding-left: 10px !important;
+  padding-right: 10px !important;
+  margin-bottom: 18px;
+  border: 1px solid var(--background-modifier-border) !important;
+  background-color: var(--background-modifier-form-field) !important;
+}
+
+input#dual-input-box {
+  font-size: 0.925em !important;
+  background-color: var(--background-modifier-form-field) !important;
+  border: 1px solid var(--background-modifier-border);
+}
+
+button#send-button {
+  border: 1px solid var(--background-modifier-border);
+}
+
+/*----------------------------------------------------------------
+DAY PLANNER PLUGIN 
+----------------------------------------------------------------*/
+
+.header_title.svelte-e43ld1.svelte-e43ld1,
+.ei_Title.svelte-e43ld1.svelte-e43ld1,
+.ce_title.svelte-e43ld1.svelte-e43ld1,
+.ei_Copy.svelte-e43ld1.svelte-e43ld1,
+.ei_Title.svelte-e43ld1.svelte-e43ld1 {
+  color: var(--text-normal) !important;
+}
+
+.theme-light .event_item.svelte-e43ld1.svelte-e43ld1 {
+  background-color: transparent !important;
+  border-bottom: 2px solid var(--background-modifier-border) !important;
+  transition: 200ms !important;
+}
+
+.theme-light .event_item.svelte-e43ld1.svelte-e43ld1:hover {
+  transition: 200ms !important;
+  background-color: transparent !important;
+  box-shadow: none !important;
+}
+
+.theme-dark .event_item.svelte-e43ld1.svelte-e43ld1 {
+  background-color: transparent !important;
+  border-bottom: 2px solid var(--background-modifier-border) !important;
+  transition: 200ms !important;
+}
+
+.theme-dark .event_item.svelte-e43ld1.svelte-e43ld1:hover {
+  transition: 200ms !important;
+  background-color: transparent !important;
+  box-shadow: none !important;
+}
+
+.aside__line.svelte-e43ld1.svelte-e43ld1 {
+  width: 2px !important;
+  background: var(--background-modifier-border) !important;
+}
+
+.ei_Dot.svelte-e43ld1.svelte-e43ld1 {
+  border-radius: 2px !important;
+}
+
+#now-line.svelte-e43ld1.svelte-e43ld1 {
+  height: 3px !important;
+  background-color: red !important;
+}
+
+.timeline-time.svelte-e43ld1 {
+  border-radius: 4px !important;
+  background-color: red !important;
+}
+
+.status-bar-item-segment.day-planner-status-bar-text > strong {
+  color: var(--text-muted) !important;
+}
+
+input#auto-scroll.toggle.svelte-e43ld1 {
+  background-color: var(--text-muted) !important;
+  border-radius: 4px !important;
+  font: var(--font-monospace) !important;
+  background-image: none !important;
+  box-shadow: none !important;
+  width: 19% !important;
+}
+
+#scroll-controls.svelte-e43ld1 .toggle.svelte-e43ld1:before {
+  border-radius: 5px !important;
+  font-size: 10px !important;
+  font-family: var(--font-monospace) !important;
+}
+
+.day-planner-status-card {
+  top: -100px !important;
+}
+
+/*----------------------------------------------------------------
+OBSIDIAN ORTHOGRAPHY PLUGIN
+----------------------------------------------------------------*/
+
+.obsidian-orthography-tooltip {
+  box-shadow: none !important;
+  background-color: var(--background-primary) !important;
+}
+
+.obsidian-orthography-highlight {
+  color: var(--text-normal) !important;
+}
+
+.obsidian-orthography-runner {
+  padding: 0.85em;
+  box-shadow: 0px 5px 25px rgba(0, 0, 0, 0.3),
+    inset 0px 3px 5px rgba(255, 255, 255, 0.2) !important;
+  background-color: var(--background-primary) !important;
+  font-size: 24px !important;
+  border: 0.1em solid rgba(255, 255, 255, 0.1) !important;
+}
+
+.obsidian-orthography-runner:hover {
+  background-color: var(--background-primary-alt) !important;
+}
+
+.obsidian-orthography-runner:active {
+  transform: translateY(2px) !important;
+}
+
+/*----------------------------------------------------------------
+KANBAN PLUGIN
+----------------------------------------------------------------*/
+
+body .kanban-plugin {
+  background: var(--background-primary) !important;
+}
+
+.kanban-plugin .tag {
+  padding: 0;
+  border: 0;
+  background-color: inherit !important;
+  color: var(--interactive-accent);
+  border-radius: 0.5em;
+}
+
+.kanban-plugin .tag:hover {
+  background-color: inherit !important;
+  color: var(--interactive-accent) !important;
+}
+
+.theme-light .kanban-plugin__lane {
+  background: var(--background-primary-alt) !important;
+}
+
+.kanban-plugin__lane {
+  padding: 0.2em 0.2em;
+}
+
+.kanban-plugin__item-prefix-button-wrapper input[type="checkbox"] {
+  margin: 3px 7px 3px 0px !important;
+}
+
+.kanban-plugin .markdown-preview-view ::-webkit-scrollbar {
+  display: none;
+}
+
+.kanban-plugin__item button,
+.kanban-plugin__lane button,
+.kanban-plugin button {
+  line-height: 1;
+  padding: 10px 12px;
+  transition: 0.1s color, 0.1s background-color;
+  margin-right: 5px !important;
+  margin-bottom: 5px;
+}
+
+.kanban-plugin__item-content-wrapper {
+  padding: 0.3em 0.3em 0.3em 0.3em !important;
+  border-radius: 1px !important;
+  background: var(--background-primary) !important;
+}
+
+.kanban-plugin__item.is-dragging {
+  border: 1px solid blue !important;
+  box-shadow: 0px 15px 25px rgba(0, 0, 0, 0.2),
+    0 0 0 2px var(--interactive-accent) !important;
+}
+
+.kanban-plugin__lane-items.is-dragging-over {
+  border: 1px solid var(--interactive-accent) !important;
+  background-color: hsl(var(--accent-hsl), 0.75) !important;
+  box-shadow: 0px 1px 5px rgba(0, 0, 0, 0.2),
+    0 0 0 2px hsl(var(--accent-hsl), 1) !important;
+}
+
+.kanban-plugin__scroll-container.kanban-plugin__vertical {
+  transition: 5ms;
+}
+
+.kanban-plugin__lane-wrapper.is-sorting
+  .kanban-plugin__scroll-container.kanban-plugin__vertical {
+  border: 1px solid var(--interactive-accent) !important;
+  background-color: hsl(var(--accent-hsl), 0.75) !important;
+  box-shadow: 0px 1px 5px rgba(0, 0, 0, 0.2),
+    0 0 0 2px hsl(var(--accent-hsl), 1) !important;
+  border-radius: 6px;
+}
+
+.kanban-plugin__item-markdown img {
+  margin: 0.25em 0em !important;
+  display: inline-block;
+}
+
+.kanban-plugin__new-item-button,
+.kanban-plugin__new-lane-button {
+  height: 3em !important;
+  background: var(--background-primary) !important;
+}
+
+.kanban-plugin__item button.kanban-plugin__item-prefix-button,
+.kanban-plugin__item button.kanban-plugin__item-postfix-button,
+.kanban-plugin__lane button.kanban-plugin__lane-settings-button {
+  box-shadow: none;
+  border: none !important;
+  line-height: 1em;
+}
+
+.kanban-plugin__new-lane-button {
+  color: var(--text-muted) !important;
+}
+
+.kanban-plugin__new-lane-button:hover,
+.kanban-plugin__new-item-button:hover {
+  color: var(--text-faint) !important;
+}
+
+.kanban-plugin__item-input {
+  line-height: 1.75em !important;
+  padding: 0.5em 0.8em 0.5em 0.8em !important;
+}
+
+.kanban-plugin__autocomplete {
+  background: var(--background-primary-alt) !important;
+  border-radius: 5px !important;
+}
+
+.choices[data-type*="select-one"]:after {
+  content: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' height='15' width='15' viewBox='0 0 20 20' focusable='false' stroke-width='px' fill='%23B9BBBE' class='dropdown-svg'%3E%3Cpath d='M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z'%3E%3C/path%3E%3C/svg%3E") !important;
+  -moz-appearance: rotate(90deg);
+  border: none !important;
+  top: 10px !important;
+  right: 24px !important;
+  background-repeat: no-repeat, repeat;
+  background-position: absolute !important;
+  background-size: 1em !important;
+  transition: 100ms;
+}
+
+/*----------------------------------------------------------------
+EXCALIDRAW PLUGIN 
+----------------------------------------------------------------*/
+
+.excalidraw .ToolIcon_type_button--show {
+  border: unset !important;
+}
+
+.excalidraw .ToolIcon__icon svg {
+  position: relative;
+  height: 1em;
+  fill: var(--icon-fill-color) !important;
+  color: var(--icon-fill-color) !important;
+}
+
+.excalidraw .help-icon {
+  color: black !important;
+  background-color: transparent !important;
+  border: transparent !important;
+}
+
+.view-action[aria-label="Save drawing"] > svg,
+.view-action[aria-label^="Force-save "] > svg {
+  background-color: currentColor;
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path d="M9 14h6v5H9zm2-9h2v2h-2z"/><path fill="none" d="M7 14c0-1.103.897-2 2-2h6c1.103 0 2 .897 2 2v5h2.001L19 8.414L15.586 5H15v4H7V5H5v14h2v-5z"/><path fill="red" d="M5 21h14c1.103 0 2-.897 2-2V8a.997.997 0 0 0-.293-.707l-4-4A.996.996 0 0 0 16 3H5c-1.103 0-2 .897-2 2v14c0 1.103.897 2 2 2zm10-2H9v-5h6v5zM13 7h-2V5h2v2zM5 5h2v4h8V5h.586L19 8.414L19.001 19H17v-5c0-1.103-.897-2-2-2H9c-1.103 0-2 .897-2 2v5H5V5z"></path></svg>');
+}
+
+/*----------------------------------------------------------------
+BUTTONS PLUGIN 
+----------------------------------------------------------------*/
+
+.button-default {
+  box-shadow: 0 3px 4px var(--text-faint, rgba(0, 0, 0, 0.05)),
+    0 1px 1px var(--text-faint, rgba(0, 0, 0, 0)) !important;
+  transition: none !important;
+  transform: translate3d(0px, -1.5px, 0px) !important;
+}
+
+.button-default:hover {
+  box-shadow: 0 1px 3px var(--button-box-shadow, rgba(0, 0, 0, 0.12)),
+    0 1px 2px var(--button-box-shadow, rgba(0, 0, 0, 0.24)) !important;
+  transform: none !important;
+  transition: all 0.15s cubic-bezier(0.25, 0.4, 0.25, 1) !important;
+}
+
+/*----------------------------------------------------------------
+DANGLING LINKS PLUGIN 
+----------------------------------------------------------------*/
+
+#dangling-links.container {
+  padding: 0px 25px;
+  font-size: 0.875em;
+}
+
+/*----------------------------------------------------------------
+DICTIONARY PLUGIN 
+----------------------------------------------------------------*/
+
+.workspace-leaf-content[data-type="dictionary-view"] {
+  font-size: 0.875em;
+}
+
+body .workspace-leaf-content[data-type="dictionary-view"] .searchbox > button {
+  padding: 0 12px;
+  color: var(--text-muted);
+  background: var(--background-primary-alt);
+  flex-shrink: 0;
+  flex-grow: 0;
+  border: 1px solid var(--background-modifier-border);
+  box-shadow: 1px 1px 0px var(--background-modifier-border);
+}
+
+.nn.svelte-19jc5lb.svelte-19jc5lb {
+  cursor: pointer;
+}
+
+.results.svelte-99gopl.svelte-99gopl {
+  margin: 0em 0.75em;
+}
+
+.svelte-jpkc8o summary,
+.svelte-fon41p summary {
+  padding: 0.15em 0.15em 0.15em 0em;
+  cursor: pointer;
+}
+
+.definition.svelte-nmuzfy.svelte-nmuzfy.svelte-nmuzfy {
+  margin: 0em 1.25em;
+}
+
+.main.svelte-nmuzfy blockquote.svelte-nmuzfy.svelte-nmuzfy:before {
+  content: "❝"; /*\edd5 \ec51*/
+  font-family: Karmilla;
+  font-weight: 900;
+  font-style: normal;
+  font-size: 2em;
+  margin-right: 0.05em;
+  line-height: 0.1em;
+  vertical-align: -0.3em;
+}
+
+.main.svelte-nmuzfy blockquote.svelte-nmuzfy.svelte-nmuzfy {
+  line-height: 1.75em;
+  color: var(--text-muted);
+  border-left: 0.3rem solid var(--background-modifier-border) !important;
+}
+
+/*STYLE SETTINGS*/
+
+.style-settings-collapse-indicator {
+  color: var(--text-faint);
+  display: inline-block;
+  margin-right: 8px;
+  position: relative;
+  top: 1px !important;
+}
+
+.style-settings-heading .style-settings-collapse-indicator > svg {
+  height: 11px;
+  width: 11px;
+}


### PR DESCRIPTION
Hey there,

I really love this theme but, unfortunately, it is now out of date in accordance with Obsidian's newer versions. As a result, it no longer displays in the theme browser. I'm aware that several issues have been raised around this:
- https://github.com/chetachiezikeuzor/Yin-and-Yang-Theme/issues/103
- https://github.com/chetachiezikeuzor/Yin-and-Yang-Theme/issues/100
- https://github.com/chetachiezikeuzor/Yin-and-Yang-Theme/issues/104

[My fork](https://github.com/DevJake/Yin-and-Yang-Theme) - and this PR - request to merge in the changes introduced by @TOB-KNPOB in [their fork](https://github.com/TOB-KNPOB/Yin-and-Yang-Theme). 

As a side note, I've included [installation instructions](https://github.com/DevJake/Yin-and-Yang-Theme/blob/main/README.md#how-to-install) within my fork should it be of value to anyone. 